### PR TITLE
Use proper Qualetize API instead of calling main()

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
         ])
         .include("external/qualetize/include")
         .include("external/qualetize/source")
-        .flag("-Dmain=qualetize_cli_entry")
+
         .flag("-std=c99")
         .flag("-O3")
         .flag("-ffast-math")

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,7 +42,7 @@ impl Default for ImageData {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct QualetizeSettings {
     pub tile_width: u16,
     pub tile_height: u16,


### PR DESCRIPTION
- Stopped calling `main()` directly.
- Now using the proper API (`Qualetize(...)` with `QualetizePlan_t`).
- Pulled in the latest commit from [Aikku93/qualetize](https://github.com/Aikku93/qualetize).  

This makes the GUI follow the intended library usage and avoids temporary file/CLI hacks.

Refs #1