### PR TITLE
added math header include file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,8 @@ fn main() {
         .flag("-std=c99")
         .flag("-O3")
         .flag("-ffast-math")
-        .flag("-funroll-loops");
+        .flag("-funroll-loops")
+        .flag(&format!("-include{}", "external/qualetize_math_header.h"));
 
     let host = std::env::var("HOST").unwrap();
     let target = std::env::var("TARGET").unwrap();

--- a/external/qualetize_math_header.h
+++ b/external/qualetize_math_header.h
@@ -1,0 +1,12 @@
+// qualetize_hack.h
+#ifndef QUALETIZE_HACK_H
+#define QUALETIZE_HACK_H
+
+#define _GNU_SOURCE
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#endif


### PR DESCRIPTION
added `external/qualetize_math_header.h`
  * this simply includes `math.h` and defines `M_PI` if not already defined

edited `build.rs` to include the new `qualetize_math_header.h`

this builds on macOS and Linux now