### PR TITLE
fixed linux build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,8 @@ fn main() {
         .flag("-std=c99")
         .flag("-O3")
         .flag("-ffast-math")
-        .flag("-funroll-loops");
+        .flag("-funroll-loops")
+        .flag(&format!("-include{}", "external/qualetize_math_header.h"));
 
     let host = std::env::var("HOST").unwrap();
     let target = std::env::var("TARGET").unwrap();

--- a/external/qualetize_math_header.h
+++ b/external/qualetize_math_header.h
@@ -1,0 +1,9 @@
+#ifndef QUALETIZE_MATH_HEADER
+#define QUALETIZE_MATH_HEADER
+#define _GNU_SOURCE
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif // M_PI
+#endif // QUALETIZE_MATH_HEADER
+


### PR DESCRIPTION
created a new file: `external/qualetize_math_header.h`
  * includes GNU math header for missing `M_PI` definition
 
edited `build.rs` to add a flag that includes this new header for building

tested and working on linux and macOS :)