### PR TITLE
fixed linux build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
             "external/qualetize/source/Cluster_Vec4f.c",
             "external/qualetize/source/DitherImage.c",
         ])
+	.define("M_PI", "3.14159265358979323846")
         .include("external/qualetize/include")
         .include("external/qualetize/source")
 


### PR DESCRIPTION
in linux (ubuntu and pop os), attempting to compile is missing a single C `#define`. this adds a line so that the value of pi is calculated the same as gcc

i tried a few different methods, and found a one line fix in `build.rs`
```
.define("M_PI", "3.14159265358979323846")
```

tested on macOS and linux :)