### PR TITLE
fixed mac building issue

### DIFF
--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -150,14 +150,16 @@ impl Default for AppState {
 
 impl AppState {
     fn same_color(&self) -> bool {
-        if let Some(pref_back_color) = self.preferences.background_color.clone()
-            && let Some(back_color) = self.background_color
-        {
-            pref_back_color == SerdeColor32::from(back_color)
-        } else if self.preferences.background_color.is_none() && self.background_color.is_none() {
-            true
-        } else {
-            false
+        match (self.preferences.background_color.clone(), self.background_color) {
+            (Some(pref_color), Some(back_color)) => {
+                pref_color == SerdeColor32::from(back_color)
+            },
+            (None, None) => {
+                true
+            },
+            _ => {
+                false
+            }
         }
     }
     pub fn check_and_save_preferences(&mut self) {


### PR DESCRIPTION
when attempting to compile on macOS, i get the following error for `src/types/app_state.rs`:

```
error[E0658]: `let` expressions in this position are unstable
   --> src/types/app_state.rs:153:12
    |
153 |         if let Some(pref_back_color) = self.preferences.background_color.clone()
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> src/types/app_state.rs:154:16
    |
154 |             && let Some(back_color) = self.background_color
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

For more information about this error, try `rustc --explain E0658`.
```

i have adjusted `src/types/app_state.rs` to account for this and it compiles just fine after this

:)