### PR TITLE
Fix/change qualetize library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/qualetize"]
 	path = external/qualetize
-	url = https://github.com/ulalume/qualetize/
+	url = https://github.com/Aikku93/qualetize/

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -321,11 +321,12 @@ fn parse_custom_levels(array_str: &str) -> Option<Vec<f32>> {
     if !validate_0_255_array(array_str) {
         return None;
     }
-    let values: Vec<f32> = array_str
+    let mut values: Vec<f32> = array_str
         .split(',')
         .filter_map(|s| s.trim().parse::<u32>().ok())
         .map(|v| (v as f32) / 255.0)
         .collect();
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     Some(values)
 }
 


### PR DESCRIPTION
Custom Levels support was originally maintained in our fork (https://github.com/ulalume/qualetize) of Aikku93’s qualetize (https://github.com/Aikku93/qualetize), but those changes have now been merged upstream. Thanks, Aikku93!
Closed PR: [https://github.com/Aikku93/qualetize/pull/3](https://github.com/Aikku93/qualetize/pull/3)

Submodule update:

* Changed the `external/qualetize` submodule URL in `.gitmodules` to point to `https://github.com/Aikku93/qualetize/` and updated the commit reference to `96b4a6b015f117ff3b6a596c34a6726dccbcaa80`. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L3-R3) [[2]](diffhunk://#diff-a40f96f63aa0f4cbf969d5a80978bb805f3b08987cce62f686c117ca4299624aL1-R1)

Custom levels parsing improvement:

* Modified `parse_custom_levels` in `src/types/qualetize.rs` to sort the parsed values after normalization, ensuring the output is ordered.