### PR TITLE
Audit cleanup, tile grid auto-extend, and 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
 dependencies = [
  "accesskit",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -88,7 +88,7 @@ checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "static_assertions",
  "windows 0.61.3",
  "windows-core 0.61.2",
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -129,11 +129,20 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
 ]
 
 [[package]]
@@ -147,23 +156,21 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cc",
- "cesu8",
  "jni",
- "jni-sys",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -183,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -198,44 +205,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -252,11 +259,11 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.2",
- "objc2-app-kit 0.3.1",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.1",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -271,7 +278,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -282,15 +289,24 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ash"
@@ -303,16 +319,16 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
 dependencies = [
  "async-fs",
  "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -349,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -363,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock",
  "blocking",
@@ -374,27 +390,27 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -414,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -427,7 +443,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.8",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -438,14 +454,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -453,10 +469,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -467,13 +483,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -534,15 +550,35 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.19",
+ "v_frame",
+ "y4m",
+]
 
 [[package]]
 name = "av1-grain"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -554,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -590,18 +626,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bitstream-io"
-version = "2.6.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block"
@@ -620,11 +659,11 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -642,34 +681,34 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.7"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -680,9 +719,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "calloop"
@@ -690,7 +729,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -699,22 +738,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop",
+ "calloop 0.13.0",
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.35"
+name = "calloop-wayland-source"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -723,32 +787,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"
@@ -787,9 +835,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -871,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -881,18 +929,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -905,6 +953,37 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "dirs"
@@ -924,7 +1003,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -935,41 +1014,41 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.9.4",
- "block2 0.6.1",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
  "libc",
- "objc2 0.6.2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -988,9 +1067,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb57dec02e4cca6d70d02e29865f7e52dbd471383f4c3444dda7ee78d467360"
+checksum = "94bdf37f8d5bd9aa7f753573fdda9cf7343afa73dd28d7bfe9593bd9798fc07e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -998,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990e96866be6346eff496e4f450616f2a00e462742ad64d955454842dd7aa006"
+checksum = "14d1c15e7bd136b309bd3487e6ffe5f668b354cd9768636a836dd738ac90eb0b"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1034,13 +1113,13 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40df1115b8b0f3d4f1f9134a26287fd3d0e067fc18f879b8c9641aedf3eecef7"
+checksum = "5d5d0306cd61ca75e29682926d71f2390160247f135965242e904a636f51c0dc"
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "emath",
  "epaint",
  "log",
@@ -1052,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b8ac3f985e46f485daa9c2c357311ac0d13098e08630ec55f3a6ad95192717"
+checksum = "c12eca13293f8eba27a32aaaa1c765bfbf31acd43e8d30d5881dcbe5e99ca0c7"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1072,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abd8326d2be6d0e945dcfe8acd2c07d64be4c977c5e1115f902dc9cd3ff7bf5"
+checksum = "f95d0a91f9cb0dc2e732d49c2d521ac8948e1f0b758f306fb7b14d6f5db3927f"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1092,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baca67871a8b808e2eb0849282f56149673b6842702306860916bf2dd83fca1"
+checksum = "cc7037813341727937f9e22f78d912f3e29bc3c46e2f40a9e82bb51cbf5e4cfb"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1110,24 +1189,24 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emath"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c95b6d5571099bfa0ae9f4fdaef2c239bccb01d55339a082070259dc6f3b05"
+checksum = "45fd7bc25f769a3c198fe1cf183124bf4de3bd62ef7b4f1eaf6b08711a3af8db"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "endi"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enumflags2"
@@ -1147,14 +1226,14 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1162,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1175,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695fd7b458f31fe515d6a308f46b2936cae9316dc40c960a7ee31ce3a97866b9"
+checksum = "63adcea970b7a13094fe97a36ab9307c35a750f9e24bf00bb7ef3de573e0fddb"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1193,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc9f86ce3eaf9b7fc7179a578af21a6a5cd2d4fd21965564e82a2d009a7dab0"
+checksum = "1537accc50c9cab5a272c39300bdd0dd5dca210f6e5e8d70be048df9596e7ca2"
 
 [[package]]
 name = "equator"
@@ -1214,7 +1293,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1225,12 +1304,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1262,14 +1341,16 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.73.0"
+version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide",
+ "num-complex",
+ "pulp",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1277,29 +1358,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1312,15 +1379,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1344,13 +1411,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1370,24 +1437,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1404,26 +1471,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1431,48 +1498,58 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "gethostname"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.0.8",
- "windows-targets 0.52.6",
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
 name = "gif"
-version = "0.13.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1507,7 +1584,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -1515,10 +1592,10 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2 0.6.2",
- "objc2-app-kit 0.3.1",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "raw-window-handle",
  "wayland-sys",
@@ -1569,21 +1646,21 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1604,9 +1681,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1615,18 +1692,19 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1637,6 +1715,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1664,12 +1748,13 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1677,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1690,11 +1775,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1705,42 +1789,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1761,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1771,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.8"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1805,18 +1885,18 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.11.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1827,93 +1907,142 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-macros",
+ "jni-sys 0.4.1",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.19",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1936,21 +2065,21 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lebe"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1958,29 +2087,30 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "libc",
- "redox_syscall 0.5.17",
+ "plain",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -1991,37 +2121,36 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -2053,15 +2182,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2081,7 +2210,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2089,12 +2218,6 @@ dependencies = [
  "objc",
  "paste",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2108,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2124,11 +2247,11 @@ checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown",
+ "hashbrown 0.15.5",
  "hexf-parse",
  "indexmap",
  "log",
@@ -2137,7 +2260,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "strum",
- "thiserror 2.0.16",
+ "thiserror 2.0.19",
  "unicode-ident",
 ]
 
@@ -2147,8 +2270,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.4",
- "jni-sys",
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -2168,7 +2291,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2177,7 +2300,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2187,16 +2310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nix"
-version = "0.30.1"
+name = "no_std_io2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
+ "memchr",
 ]
 
 [[package]]
@@ -2207,12 +2326,11 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2223,11 +2341,21 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2239,7 +2367,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2274,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2284,14 +2412,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2321,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -2334,7 +2462,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2346,16 +2474,16 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.4",
- "block2 0.6.1",
- "objc2 0.6.2",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.1",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2364,7 +2492,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2388,7 +2516,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2396,24 +2524,24 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "dispatch2",
- "objc2 0.6.2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "dispatch2",
- "objc2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2454,7 +2582,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -2463,23 +2591,23 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.4",
- "objc2 0.6.2",
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-io-surface"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.9.4",
- "objc2 0.6.2",
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2501,7 +2629,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2513,7 +2641,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2536,7 +2664,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2568,7 +2696,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2577,15 +2705,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -2595,10 +2723,11 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.48"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
+ "libc",
  "libredox",
 ]
 
@@ -2638,9 +2767,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2648,15 +2777,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2666,6 +2795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,41 +2808,35 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -2716,17 +2845,23 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2735,16 +2870,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2755,24 +2890,24 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2794,49 +2929,69 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.20"
+name = "pulp"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e790881194f6f6e86945f0a42a6981977323669aeb6c40e9c7ec253133b96f8"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
- "num-traits",
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
 ]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qoi"
@@ -2873,28 +3028,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2906,34 +3051,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2943,42 +3073,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "range-alloc"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rav1e"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
 dependencies = [
+ "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
  "arrayvec",
+ "av-scenechange",
  "av1-grain",
  "bitstream-io",
  "built",
@@ -2993,23 +3116,21 @@ dependencies = [
  "noop_proc_macro",
  "num-derive",
  "num-traits",
- "once_cell",
  "paste",
  "profiling",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "simd_helpers",
- "system-deps",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "v_frame",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "ravif"
-version = "0.11.20"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -3021,6 +3142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,9 +3158,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3047,6 +3177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,11 +3193,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3070,16 +3215,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.16",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3089,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3100,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"
@@ -3117,14 +3262,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
  "ashpd",
- "block2 0.6.1",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "log",
- "objc2 0.6.2",
- "objc2-app-kit 0.3.1",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation 0.3.2",
  "pollster",
  "raw-window-handle",
  "urlencoding",
@@ -3136,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rustc-hash"
@@ -3148,9 +3293,18 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3158,7 +3312,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3167,28 +3321,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -3220,82 +3368,101 @@ dependencies = [
  "ab_glyph",
  "log",
  "memmap2",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -3307,25 +3474,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.11"
+name = "simdutf8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
-version = "1.0.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3333,9 +3506,9 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.9.4",
- "calloop",
- "calloop-wayland-source",
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
  "cursor-icon",
  "libc",
  "log",
@@ -3353,13 +3526,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "smithay-clipboard"
-version = "0.7.2"
+name = "smithay-client-toolkit"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.19",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
 dependencies = [
  "libc",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.20.0",
  "wayland-backend",
 ]
 
@@ -3378,14 +3578,14 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -3418,14 +3618,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3440,39 +3651,20 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
-
-[[package]]
-name = "system-deps"
-version = "6.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml",
- "version-compare",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3495,11 +3687,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3510,25 +3702,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
@@ -3565,54 +3757,51 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3620,20 +3809,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3650,48 +3839,49 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3713,6 +3903,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,12 +3923,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "version-compare"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -3752,58 +3947,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3811,35 +3990,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.11"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -3847,12 +4026,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.11"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
- "bitflags 2.9.4",
- "rustix 1.0.8",
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3863,41 +4042,67 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.9"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
 ]
 
 [[package]]
-name = "wayland-protocols-plasma"
-version = "0.3.9"
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3906,11 +4111,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3919,20 +4124,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.37.5",
+ "quick-xml",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -3942,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3962,25 +4167,25 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.5"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf4f3c0ba838e82b4e5ccc4157003fb8c324ee24c058470ffb82820becbde98"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
- "objc2 0.6.2",
- "objc2-foundation 0.3.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "url",
  "web-sys",
 ]
 
 [[package]]
 name = "weezl"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
@@ -3989,10 +4194,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "log",
  "naga",
@@ -4019,10 +4224,10 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "log",
  "naga",
@@ -4033,7 +4238,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.19",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -4078,7 +4283,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block",
  "bytemuck",
  "cfg-if",
@@ -4089,7 +4294,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -4107,7 +4312,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -4121,11 +4326,11 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.16",
+ "thiserror 2.0.19",
  "web-sys",
 ]
 
@@ -4147,11 +4352,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4179,7 +4384,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -4211,9 +4416,9 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -4225,7 +4430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -4237,18 +4442,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4259,18 +4464,18 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4280,13 +4485,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4304,7 +4515,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4323,16 +4534,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4359,22 +4561,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.42.2"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4395,19 +4591,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4416,14 +4612,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4433,15 +4623,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4451,15 +4635,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4469,9 +4647,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -4481,15 +4659,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4499,15 +4671,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4517,15 +4683,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4535,15 +4695,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4553,23 +4707,23 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.30.12"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
@@ -4591,7 +4745,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -4611,24 +4765,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11-dl"
@@ -4652,7 +4806,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -4674,7 +4828,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.1",
  "dlib",
  "log",
  "once_cell",
@@ -4689,17 +4843,22 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4707,21 +4866,21 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.10.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -4737,13 +4896,15 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "libc",
  "ordered-stream",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
- "windows-sys 0.60.2",
+ "uuid",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -4752,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -4762,13 +4923,13 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -4776,14 +4937,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.10.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -4791,75 +4952,73 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.2.0"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "static_assertions",
  "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.0.2"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
- "quick-xml 0.36.2",
  "serde",
- "static_assertions",
+ "winnow",
  "zbus_names",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4868,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4879,20 +5038,26 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "zune-core"
-version = "0.4.12"
+name = "zmij"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-inflate"
@@ -4905,18 +5070,18 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.20"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
 
 [[package]]
 name = "zvariant"
-version = "5.7.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4929,26 +5094,26 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.7.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.119",
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,8 @@ dependencies = [
  "accesskit_consumer 0.35.0",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2826,7 +2826,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4494,9 +4494,9 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
- "windows-result 0.4.1",
+ "windows",
+ "windows-core",
+ "windows-result",
 ]
 
 [[package]]
@@ -4534,36 +4534,15 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
 dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4572,20 +4551,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4596,20 +4562,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4618,9 +4573,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4647,25 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -4673,17 +4612,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4692,16 +4622,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4710,7 +4631,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4746,7 +4667,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4771,7 +4692,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4784,20 +4705,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "qualetize_gui"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "cc",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,43 +20,66 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.19.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.12.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bd41de2e54451a8ca0dd95ebf45b54d349d29ebceb7f20be264eee14e3d477"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.36.0",
  "atspi-common",
+ "phf",
  "serde",
- "thiserror 1.0.69",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.28.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.20.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -64,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.15.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f7474c36606d0fe4f438291d667bae7042ea2760f506650ad2366926358fc8"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -82,23 +105,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.27.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.27.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f0d3d13113d8857542a4f8d1a1c24d1dc1527b77aee8426127f4901588708"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -155,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +197,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 2.0.19",
 ]
@@ -456,20 +485,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
 dependencies = [
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
 dependencies = [
  "enumflags2",
  "serde",
@@ -482,22 +510,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-connection"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
 name = "atspi-proxies"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
@@ -555,18 +571,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -585,9 +601,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bitstream-io"
@@ -597,12 +610,6 @@ checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -774,13 +781,22 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1023,9 +1039,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bdf37f8d5bd9aa7f753573fdda9cf7343afa73dd28d7bfe9593bd9798fc07e"
+checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1033,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d1c15e7bd136b309bd3487e6ffe5f668b354cd9768636a836dd738ac90eb0b"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1044,17 +1060,17 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
  "glutin",
  "glutin-winit",
  "image",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
+ "pollster",
  "profiling",
  "raw-window-handle",
  "static_assertions",
@@ -1062,22 +1078,23 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "winapi",
- "windows-sys 0.59.0",
+ "wgpu",
+ "windows-sys 0.61.2",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5d0306cd61ca75e29682926d71f2390160247f135965242e904a636f51c0dc"
+checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.13.1",
  "emath",
  "epaint",
+ "itertools",
  "log",
  "nohash-hasher",
  "profiling",
@@ -1087,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12eca13293f8eba27a32aaaa1c765bfbf31acd43e8d30d5881dcbe5e99ca0c7"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1098,7 +1115,7 @@ dependencies = [
  "epaint",
  "log",
  "profiling",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "type-map",
  "web-time",
  "wgpu",
@@ -1107,16 +1124,18 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95d0a91f9cb0dc2e732d49c2d521ac8948e1f0b758f306fb7b14d6f5db3927f"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
 dependencies = [
  "accesskit_winit",
- "ahash",
  "arboard",
  "bytemuck",
  "egui",
  "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "profiling",
  "raw-window-handle",
  "smithay-clipboard",
@@ -1127,19 +1146,16 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7037813341727937f9e22f78d912f3e29bc3c46e2f40a9e82bb51cbf5e4cfb"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
 dependencies = [
- "ahash",
  "bytemuck",
  "egui",
  "glow",
  "log",
  "memoffset",
  "profiling",
- "wasm-bindgen",
- "web-sys",
  "winit",
 ]
 
@@ -1151,9 +1167,9 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emath"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd7bc25f769a3c198fe1cf183124bf4de3bd62ef7b4f1eaf6b08711a3af8db"
+checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
 dependencies = [
  "bytemuck",
 ]
@@ -1210,27 +1226,34 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63adcea970b7a13094fe97a36ab9307c35a750f9e24bf00bb7ef3de573e0fddb"
+checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
 dependencies = [
- "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "font-types",
+ "harfrust",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.32.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1537accc50c9cab5a272c39300bdd0dd5dca210f6e5e8d70be048df9596e7ca2"
+checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
 
 [[package]]
 name = "equator"
@@ -1273,6 +1296,15 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "event-listener"
@@ -1334,6 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1392,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1512,10 +1565,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "glow"
-version = "0.16.0"
+name = "glifo"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1590,34 +1659,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
-dependencies = [
- "bitflags 2.13.1",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.19",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1641,6 +1693,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,12 +1714,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1666,12 +1750,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2009,6 +2090,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,15 +2206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,21 +2240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,25 +2261,26 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "25.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.13.1",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
  "thiserror 2.0.19",
  "unicode-ident",
 ]
@@ -2218,7 +2294,7 @@ dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2229,15 +2305,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys 0.3.1",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2368,15 +2435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,7 +2472,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -2500,7 +2558,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2541,6 +2599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2581,6 +2640,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,7 +2661,20 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -2618,10 +2702,22 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2746,10 +2842,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2832,6 +2984,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3102,6 +3263,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3292,16 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -3321,6 +3504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3617,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -3546,28 +3751,6 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "syn"
@@ -3802,6 +3985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,6 +4052,34 @@ dependencies = [
  "aligned-vec",
  "num-traits",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "smallvec",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
 ]
 
 [[package]]
@@ -4130,15 +4347,17 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "25.0.2"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
  "naga",
@@ -4158,17 +4377,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "25.0.2"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
  "bitflags 2.13.1",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
@@ -4182,114 +4402,126 @@ dependencies = [
  "thiserror 2.0.19",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "25.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "25.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "25.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "25.0.2"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.13.1",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
  "ordered-float",
  "parking_lot",
  "portable-atomic",
+ "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.19",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "25.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.19",
+ "raw-window-handle",
  "web-sys",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -4301,32 +4533,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4339,16 +4567,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4357,11 +4581,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -4372,18 +4609,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4391,17 +4628,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4442,12 +4668,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4460,13 +4687,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-strings"
-version = "0.1.0"
+name = "windows-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4476,6 +4702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4554,6 +4789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4678,7 +4922,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,28 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,17 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,17 +382,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -1436,15 +1392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,10 +1440,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -3257,26 +3202,29 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rfd"
-version = "0.15.4"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "ashpd",
  "block2 0.6.2",
  "dispatch2",
  "js-sys",
+ "libc",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "percent-encoding",
  "pollster",
  "raw-window-handle",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3881,14 +3829,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -5086,7 +5027,6 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
  "winnow",
  "zvariant_derive",
  "zvariant_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ icon = ["assets/icon.icns"]
 eframe = "0.32"
 egui = "0.32"
 image = "0.25"
-rfd = "0.15"
+rfd = "0.17"
 env_logger = "0.11"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qualetize_gui"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ identifier = "io.github.ulalume.qualetize_gui"
 icon = ["assets/icon.icns"]
 
 [dependencies]
-eframe = "0.32"
-egui = "0.32"
+eframe = "0.35"
+egui = "0.35"
 image = "0.25"
 rfd = "0.17"
 env_logger = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ png = "0.18"
 regex = "1.11"
 
 [build-dependencies]
-cc = "*"
+cc = "1.4"
 
 [profile.dev]
 opt-level = 1

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,9 @@ use crate::exporter::{save_indexed_bmp, save_indexed_png, save_rgba_image};
 use crate::image_processor::ImageProcessor;
 use crate::settings_manager::SettingsBundle;
 use crate::types::ImageData;
-use crate::types::app_state::{AppStateRequest, AppearanceMode, ExportSource, QualetizeRequest};
+use crate::types::app_state::{
+    AppStateRequest, AppearanceMode, ExportSource, FittedInput, QualetizeRequest, Toast,
+};
 use crate::types::image::{ImageDataIndexed, SortMode, TileCountOptions};
 use crate::types::{AppState, ExportFormat};
 use crate::ui::{
@@ -72,9 +74,6 @@ impl QualetizeApp {
                 self.state.input_path = Some(path);
                 self.state.input_image = Some(image_data);
 
-                // Check tile size compatibility
-                self.check_tile_size_compatibility();
-
                 self.state.zoom = 1.0;
                 self.state.pan_offset = egui::Vec2::ZERO;
             }
@@ -86,9 +85,6 @@ impl QualetizeApp {
     }
 
     fn handle_settings_changes(&mut self) {
-        if !self.check_tile_size_compatibility() {
-            return;
-        }
         let Some(color_corrected_image) = &self.state.color_corrected_image else {
             return;
         };
@@ -113,35 +109,47 @@ impl QualetizeApp {
         self.state.request_update_tile_reduce = self.state.settings.tile_reduce_post_enabled;
     }
 
-    fn check_tile_size_compatibility(&mut self) -> bool {
-        let Some(input_image) = &self.state.input_image else {
-            return true;
+    /// Extend the input image so both sides are a multiple of the tile size,
+    /// filling the added area with the top-left pixel color.
+    ///
+    /// The loaded image is never modified, so changing the tile size later
+    /// re-derives the extension from it instead of compounding.
+    /// Returns true when the image the pipeline runs on changed.
+    fn update_tile_fit(&mut self, ctx: &egui::Context) -> bool {
+        let Some(input) = &self.state.input_image else {
+            return self.state.tile_fitted_input.take().is_some();
         };
 
-        let image_width = input_image.width as u16;
-        let image_height = input_image.height as u16;
-        let tile_width = self.state.settings.tile_width;
-        let tile_height = self.state.settings.tile_height;
-
-        let width_divisible = image_width.is_multiple_of(tile_width);
-        let height_divisible = image_height.is_multiple_of(tile_height);
-
-        log::debug!(
-            "Tile size check: image {image_width}×{image_height}, tile {tile_width}×{tile_height}, divisible: width={width_divisible}, height={height_divisible}"
+        let target = tile_fit_target(
+            (input.width, input.height),
+            self.state.settings.tile_width,
+            self.state.settings.tile_height,
         );
 
-        if !width_divisible || !height_divisible {
-            self.state.tile_size_warning = true;
-            self.state.output_image = None;
-            self.state.invalidate_palette_sort();
-            self.state.tile_count.reset();
-            log::warn!("Tile size warning");
-            false
-        } else {
-            self.state.tile_size_warning = false;
-            log::debug!("No warning - sizes are compatible");
-            true
+        if target == (input.width, input.height) {
+            return self.state.tile_fitted_input.take().is_some();
         }
+        if let Some(fitted) = &self.state.tile_fitted_input
+            && (fitted.image.width, fitted.image.height) == target
+        {
+            return false;
+        }
+
+        log::info!(
+            "Extending {}×{} to {}×{} to fit the tile grid",
+            input.width,
+            input.height,
+            target.0,
+            target.1
+        );
+        let image = input.extended_to(target.0, target.1, input.top_left_pixel(), ctx);
+        self.state.tile_fitted_input = Some(FittedInput {
+            image,
+            original_size: (input.width, input.height),
+        });
+        self.state.tile_fit_toast =
+            Some(Toast::new(format!("Extended to {}×{}", target.0, target.1)));
+        true
     }
 
     fn update_color_corrected_image(&mut self, ctx: &egui::Context) {
@@ -241,10 +249,8 @@ impl QualetizeApp {
                                 .map(|reduced| base.saturating_sub(reduced))
                         })
                         .unwrap_or(res.merged);
-                    self.state.tile_reduce_toast = Some(crate::types::app_state::TileReduceToast {
-                        message: format!("Reduced {} tiles", diff),
-                        time: std::time::Instant::now(),
-                    });
+                    self.state.tile_reduce_toast =
+                        Some(Toast::new(format!("Reduced {diff} tiles")));
                     self.state.tile_count.mark_dirty();
                     log::info!("Tile reduce completed: merged {}", res.merged);
                 }
@@ -271,7 +277,7 @@ impl QualetizeApp {
     }
 
     fn apply_color_correct_image(&mut self, ctx: &egui::Context) {
-        let Some(image) = &self.state.input_image else {
+        let Some(image) = self.state.processing_input() else {
             return;
         };
 
@@ -420,6 +426,7 @@ impl QualetizeApp {
         match app_state_request {
             AppStateRequest::LoadImage { path } => {
                 self.load_image_file(path.clone(), ctx);
+                self.update_tile_fit(ctx);
                 self.apply_color_correct_image(ctx);
                 self.state.request_update_qualetized_image = Some(QualetizeRequest {
                     time: std::time::Instant::now(),
@@ -468,6 +475,7 @@ impl QualetizeApp {
                         });
 
                         if self.state.input_image.is_some() {
+                            self.update_tile_fit(ctx);
                             self.apply_color_correct_image(ctx);
                         } else {
                             self.state.color_corrected_image = None;
@@ -594,7 +602,13 @@ impl eframe::App for QualetizeApp {
         // Check tile reduce completion
         self.check_tile_reduce_completion(ctx);
 
-        // Update color corrected image if needed
+        // Re-extend if the tile size changed, then update the corrected image
+        if self.update_tile_fit(ctx) {
+            self.apply_color_correct_image(ctx);
+            self.state.request_update_qualetized_image = Some(QualetizeRequest {
+                time: std::time::Instant::now(),
+            });
+        }
         self.update_color_corrected_image(ctx);
 
         // Handle settings changes after checking completion
@@ -684,6 +698,14 @@ impl eframe::App for QualetizeApp {
     }
 }
 
+/// Smallest size at or above `size` whose sides are multiples of the tile size.
+fn tile_fit_target(size: (u32, u32), tile_width: u16, tile_height: u16) -> (u32, u32) {
+    (
+        size.0.next_multiple_of(tile_width.max(1) as u32),
+        size.1.next_multiple_of(tile_height.max(1) as u32),
+    )
+}
+
 /// Build the default export path for `input_path`.
 ///
 /// The extension is appended rather than set via [`std::path::Path::with_extension`],
@@ -747,6 +769,30 @@ mod tests {
         get_export_path(input, &format, suffix)
             .to_string_lossy()
             .into_owned()
+    }
+
+    #[test]
+    fn a_size_already_on_the_tile_grid_is_left_alone() {
+        assert_eq!(tile_fit_target((96, 96), 8, 8), (96, 96));
+        assert_eq!(tile_fit_target((64, 32), 16, 16), (64, 32));
+    }
+
+    #[test]
+    fn a_size_off_the_grid_grows_to_the_next_multiple() {
+        assert_eq!(tile_fit_target((100, 100), 8, 8), (104, 104));
+        assert_eq!(tile_fit_target((100, 100), 7, 7), (105, 105));
+        assert_eq!(tile_fit_target((17, 3), 8, 8), (24, 8));
+    }
+
+    #[test]
+    fn each_axis_uses_its_own_tile_size() {
+        assert_eq!(tile_fit_target((100, 100), 8, 16), (104, 112));
+    }
+
+    /// An image smaller than one tile still has to grow to a full tile.
+    #[test]
+    fn an_image_smaller_than_a_tile_grows_to_one_tile() {
+        assert_eq!(tile_fit_target((3, 5), 8, 8), (8, 8));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,14 +66,9 @@ impl QualetizeApp {
 
         match ImageData::load(&path, ctx) {
             Ok(image_data) => {
-                self.state.input_path = Some(path.clone());
+                self.state.reset_all_images();
+                self.state.input_path = Some(path);
                 self.state.input_image = Some(image_data);
-                self.state.color_corrected_image = None;
-                self.state.base_output_image = None;
-                self.state.output_image = None;
-                self.state.base_tile_count = None;
-                self.state.reduced_tile_count = None;
-                self.state.request_update_tile_reduce = false;
 
                 // Check tile size compatibility
                 self.check_tile_size_compatibility();
@@ -83,14 +78,7 @@ impl QualetizeApp {
             }
             Err(e) => {
                 log::error!("File load Error {e}");
-                self.state.input_path = None;
-                self.state.input_image = Default::default();
-                self.state.color_corrected_image = None;
-                self.state.base_output_image = None;
-                self.state.output_image = None;
-                self.state.base_tile_count = None;
-                self.state.reduced_tile_count = None;
-                self.state.request_update_tile_reduce = false;
+                self.state.reset_all_images();
             }
         }
     }
@@ -144,8 +132,7 @@ impl QualetizeApp {
             self.state.tile_size_warning = true;
             self.state.output_image = None;
             self.state.invalidate_palette_sort();
-            self.state.tile_count.last_count = None;
-            self.state.tile_count.mark_dirty();
+            self.state.tile_count.reset();
             log::warn!("Tile size warning");
             false
         } else {
@@ -187,19 +174,12 @@ impl QualetizeApp {
                         self.handle_tile_reduce_changes(ctx);
                     }
                     self.state.invalidate_palette_sort();
-                    self.state.tile_count.last_count = None;
-                    self.state.tile_count.mark_dirty();
+                    self.state.tile_count.reset();
                 }
                 Err(e) => {
                     log::error!("Failed to generate preview image: {e}");
-                    self.state.output_image = None;
-                    self.state.base_output_image = None;
-                    self.state.base_tile_count = None;
-                    self.state.reduced_tile_count = None;
-                    self.state.invalidate_palette_sort();
-                    self.state.tile_count.last_count = None;
+                    self.state.reset_qualetize_outputs();
                     self.state.tile_reduce_processing = false;
-                    self.state.tile_count.mark_dirty();
                 }
             }
         }
@@ -413,15 +393,13 @@ impl QualetizeApp {
                     return;
                 };
 
-                let indexed = if self.state.output_palette_sorted_indexed_image.is_some() {
-                    &self.state.output_palette_sorted_indexed_image
-                } else if let Some(image) = &self.state.output_image {
-                    &image.indexed
-                } else {
-                    &None
-                };
-
-                let Some(indexed) = indexed else {
+                // Prefer the sorted palette when one is active.
+                let Some(indexed) = self
+                    .state
+                    .output_palette_sorted_indexed_image
+                    .as_ref()
+                    .or(output_image.indexed.as_ref())
+                else {
                     return;
                 };
 
@@ -748,8 +726,6 @@ impl eframe::App for QualetizeApp {
         {
             ctx.request_repaint();
         }
-
-        // enforce high quality always
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -265,7 +265,7 @@ impl QualetizeApp {
                 None => egui::Visuals::dark(),
             },
         };
-        if ctx.style().visuals != visuals {
+        if ctx.global_style().visuals != visuals {
             ctx.set_visuals(visuals);
         }
     }
@@ -613,7 +613,9 @@ impl Drop for QualetizeApp {
 }
 
 impl eframe::App for QualetizeApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // The Qualetized and Tile Reduced panels show their own spinners, so the
         // two stages are tracked separately (`state.tile_reduce_processing`).
         let qualetize_processing = self.image_processor.is_processing();
@@ -655,7 +657,7 @@ impl eframe::App for QualetizeApp {
         // central panel is sized as if they were not there.
 
         // Top (menu)
-        egui::TopBottomPanel::top("menu_panel").show(ctx, |ui| {
+        egui::Panel::top("menu_panel").show(ui, |ui| {
             egui::Frame::NONE
                 .inner_margin(Margin::symmetric(0, 4))
                 .show(ui, |ui| {
@@ -665,7 +667,7 @@ impl eframe::App for QualetizeApp {
 
         // Bottom (zoom / export / tile count)
         if self.state.input_image.is_some() {
-            egui::TopBottomPanel::bottom("footer").show(ctx, |ui| {
+            egui::Panel::bottom("footer").show(ui, |ui| {
                 egui::Frame::NONE
                     .inner_margin(Margin::symmetric(0, 4))
                     .show(ui, |ui| {
@@ -675,10 +677,10 @@ impl eframe::App for QualetizeApp {
         }
 
         // Left (settings)
-        egui::SidePanel::left("settings_panel")
-            .default_width(260.0)
+        egui::Panel::left("settings_panel")
+            .default_size(260.0)
             .resizable(true)
-            .show(ctx, |ui| {
+            .show(ui, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     let (settings, tile_reduce) = draw_settings_panel(ui, &mut self.state);
                     settings_changed |= settings;
@@ -687,13 +689,13 @@ impl eframe::App for QualetizeApp {
             });
 
         // Center (images)
-        egui::CentralPanel::default()
+        egui::CentralPanel::default_margins()
             .frame(
                 egui::Frame::default()
                     .inner_margin(0.0)
-                    .fill(ctx.style().visuals.window_fill()),
+                    .fill(ctx.global_style().visuals.window_fill()),
             )
-            .show(ctx, |ui| {
+            .show(ui, |ui| {
                 if self.state.input_path.is_none() {
                     draw_main_content(ui);
                 } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,9 @@ use crate::types::ImageData;
 use crate::types::app_state::{AppStateRequest, AppearanceMode, QualetizeRequest};
 use crate::types::image::{ImageDataIndexed, SortMode, TileCountOptions};
 use crate::types::{AppState, ExportFormat};
-use crate::ui::UI;
+use crate::ui::{
+    draw_footer, draw_header, draw_image_view, draw_main_content, draw_settings_panel,
+};
 use eframe::egui;
 use egui::{ColorImage, Margin};
 use rfd::FileDialog;
@@ -340,6 +342,26 @@ impl QualetizeApp {
         ImageData::count_unique_tiles(indexed, image.width, image.height, tile_w, tile_h, options)
     }
 
+    /// Run a native file dialog on a worker thread so the UI keeps repainting,
+    /// and feed whatever the user picked back into the request channel.
+    ///
+    /// `file_dialog_open` is held for the lifetime of the dialog so drag & drop
+    /// is ignored while it is up.
+    fn spawn_file_dialog<F>(&self, pick: F)
+    where
+        F: FnOnce(FileDialog) -> Option<AppStateRequest> + Send + 'static,
+    {
+        let sender = self.state.app_state_request_sender.clone();
+        let dialog_flag = self.state.file_dialog_open.clone();
+
+        std::thread::spawn(move || {
+            let _guard = FileDialogGuard::new(dialog_flag);
+            if let Some(request) = pick(FileDialog::new()) {
+                _ = sender.send(request);
+            }
+        });
+    }
+
     fn handle_requests(&mut self, ctx: &egui::Context) {
         // Check for file dialog results first
         let Ok(app_state_request) = &self.state.app_state_request_receiver.try_recv() else {
@@ -494,99 +516,60 @@ impl QualetizeApp {
                 }
             }
             AppStateRequest::OpenImageDialog => {
-                let sender = self.state.app_state_request_sender.clone();
-                let dialog_flag = self.state.file_dialog_open.clone();
-                std::thread::spawn(move || {
-                    let _guard = FileDialogGuard::new(dialog_flag);
-                    let dialog = FileDialog::new()
-                        .add_filter("Image files", &["png", "jpg", "jpeg", "bmp", "tga", "tiff"]);
-
-                    let Some(path) = dialog.pick_file() else {
-                        return;
-                    };
-                    _ = sender.send(AppStateRequest::LoadImage {
+                self.spawn_file_dialog(|dialog| {
+                    let path = dialog
+                        .add_filter("Image files", &["png", "jpg", "jpeg", "bmp", "tga", "tiff"])
+                        .pick_file()?;
+                    Some(AppStateRequest::LoadImage {
                         path: path.display().to_string(),
-                    });
+                    })
                 });
             }
             AppStateRequest::ExportImageDialog { format, suffix } => {
-                let sender = self.state.app_state_request_sender.clone();
                 let Some(input_path) = self.state.input_path.clone() else {
                     return;
                 };
                 let default_path = get_export_path(&input_path, format, suffix.as_deref());
-                let format_clone = *format;
+                let format = *format;
 
-                let dialog_flag = self.state.file_dialog_open.clone();
-                std::thread::spawn(move || {
-                    let _guard = FileDialogGuard::new(dialog_flag);
-                    let mut dialog = FileDialog::new().add_filter(
-                        format!("{} files", format_clone.display_name()),
-                        &[format_clone.extension()],
+                self.spawn_file_dialog(move |dialog| {
+                    let mut dialog = dialog.add_filter(
+                        format!("{} files", format.display_name()),
+                        &[format.extension()],
                     );
-                    if let Some(filename) = default_path.file_name() {
-                        dialog = dialog.set_file_name(filename.to_string_lossy().to_string());
+                    if let Some(file_name) = default_path.file_name() {
+                        dialog = dialog.set_file_name(file_name.to_string_lossy().to_string());
                     }
                     if let Some(parent) = default_path.parent() {
                         dialog = dialog.set_directory(parent);
                     }
-                    let Some(file) = dialog.save_file() else {
-                        return;
-                    };
-                    let export_request = match format_clone {
-                        crate::types::ExportFormat::Png => AppStateRequest::ColorCorrectedPng {
-                            output_path: file.display().to_string(),
-                        },
+
+                    let output_path = dialog.save_file()?.display().to_string();
+                    Some(match format {
+                        ExportFormat::Png => AppStateRequest::ColorCorrectedPng { output_path },
                         _ => AppStateRequest::QualetizedIndexed {
-                            output_path: file.display().to_string(),
-                            format: format_clone,
+                            output_path,
+                            format,
                         },
-                    };
-                    _ = sender.send(export_request);
+                    })
                 });
             }
             AppStateRequest::SaveSettingsDialog => {
-                let sender = self.state.app_state_request_sender.clone();
-                let dialog_flag = self.state.file_dialog_open.clone();
-                std::thread::spawn(move || {
-                    let _guard = FileDialogGuard::new(dialog_flag);
-                    let mut dialog = FileDialog::new()
-                        .add_filter(
-                            "QualetizeGUI Settings",
-                            &[SettingsBundle::get_settings_file_extension()],
-                        )
-                        .set_file_name("qualetize_settings.qset");
-
-                    if let Ok(settings_dir) = SettingsBundle::get_default_settings_dir() {
-                        dialog = dialog.set_directory(&settings_dir);
-                    }
-
-                    let Some(file) = dialog.pick_file() else {
-                        return;
-                    };
-                    _ = sender.send(AppStateRequest::SaveSettings {
-                        path: file.display().to_string(),
-                    });
+                self.spawn_file_dialog(|dialog| {
+                    let path = settings_file_dialog(dialog)
+                        .set_file_name("qualetize_settings.qset")
+                        .pick_file()?;
+                    Some(AppStateRequest::SaveSettings {
+                        path: path.display().to_string(),
+                    })
                 });
             }
             AppStateRequest::LoadSettingsDialog => {
-                let sender = self.state.app_state_request_sender.clone();
-                let dialog_flag = self.state.file_dialog_open.clone();
-                std::thread::spawn(move || {
-                    let _guard = FileDialogGuard::new(dialog_flag);
-                    let mut dialog = FileDialog::new().add_filter(
-                        "QualetizeGUI Settings",
-                        &[SettingsBundle::get_settings_file_extension()],
-                    );
-                    if let Ok(settings_dir) = SettingsBundle::get_default_settings_dir() {
-                        dialog = dialog.set_directory(&settings_dir);
-                    }
-                    let Some(file) = dialog.pick_file() else {
-                        return;
-                    };
-                    _ = sender.send(AppStateRequest::LoadSettings {
-                        path: file.display().to_string(),
-                    });
+                self.spawn_file_dialog(|dialog| {
+                    let path = settings_file_dialog(dialog).pick_file()?;
+                    Some(AppStateRequest::LoadSettings {
+                        path: path.display().to_string(),
+                    })
                 });
             }
         }
@@ -661,28 +644,43 @@ impl eframe::App for QualetizeApp {
 
         let mut settings_changed = false;
         let mut tile_reduce_changed = false;
-        // Top（Menu）
+
+        // Panels have to be declared before the central panel, otherwise the
+        // central panel is sized as if they were not there.
+
+        // Top (menu)
         egui::TopBottomPanel::top("menu_panel").show(ctx, |ui| {
             egui::Frame::NONE
                 .inner_margin(Margin::symmetric(0, 4))
                 .show(ui, |ui| {
-                    settings_changed |= UI::draw_header(ui, &mut self.state);
+                    settings_changed |= draw_header(ui, &mut self.state);
                 });
         });
 
-        // Side（Settings）
+        // Bottom (zoom / export / tile count)
+        if self.state.input_image.is_some() {
+            egui::TopBottomPanel::bottom("footer").show(ctx, |ui| {
+                egui::Frame::NONE
+                    .inner_margin(Margin::symmetric(0, 4))
+                    .show(ui, |ui| {
+                        draw_footer(ui, &mut self.state);
+                    });
+            });
+        }
+
+        // Left (settings)
         egui::SidePanel::left("settings_panel")
             .default_width(260.0)
             .resizable(true)
             .show(ctx, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
-                    let (settings, tile_reduce) = UI::draw_settings_panel(ui, &mut self.state);
+                    let (settings, tile_reduce) = draw_settings_panel(ui, &mut self.state);
                     settings_changed |= settings;
                     tile_reduce_changed |= tile_reduce;
                 });
             });
 
-        // Main（Images）
+        // Center (images)
         egui::CentralPanel::default()
             .frame(
                 egui::Frame::default()
@@ -690,22 +688,10 @@ impl eframe::App for QualetizeApp {
                     .fill(ctx.style().visuals.window_fill()),
             )
             .show(ctx, |ui| {
-                // Main
                 if self.state.input_path.is_none() {
-                    UI::draw_main_content(ui);
+                    draw_main_content(ui);
                 } else {
-                    UI::draw_image_view(ui, &mut self.state, image_processing);
-                }
-
-                // Footer
-                if self.state.input_image.is_some() {
-                    egui::TopBottomPanel::bottom("footer").show(ctx, |ui| {
-                        egui::Frame::NONE
-                            .inner_margin(Margin::symmetric(0, 4))
-                            .show(ui, |ui| {
-                                UI::draw_footer(ui, &mut self.state);
-                            });
-                    });
+                    draw_image_view(ui, &mut self.state, image_processing);
                 }
             });
 
@@ -752,6 +738,18 @@ fn get_export_path(
         None => format!("{stem}.{extension}"),
     };
     parent.join(file_name)
+}
+
+/// Filter and starting directory shared by the settings load/save dialogs.
+fn settings_file_dialog(dialog: FileDialog) -> FileDialog {
+    let mut dialog = dialog.add_filter(
+        "QualetizeGUI Settings",
+        &[SettingsBundle::get_settings_file_extension()],
+    );
+    if let Ok(settings_dir) = SettingsBundle::get_default_settings_dir() {
+        dialog = dialog.set_directory(&settings_dir);
+    }
+    dialog
 }
 
 pub struct FileDialogGuard {

--- a/src/app.rs
+++ b/src/app.rs
@@ -143,7 +143,7 @@ impl QualetizeApp {
         if !width_divisible || !height_divisible {
             self.state.tile_size_warning = true;
             self.state.output_image = None;
-            self.state.output_palette_sorted_indexed_image = None;
+            self.state.invalidate_palette_sort();
             self.state.tile_count.last_count = None;
             self.state.tile_count.mark_dirty();
             log::warn!("Tile size warning");
@@ -180,14 +180,13 @@ impl QualetizeApp {
                         || self.state.settings.tile_reduce_post_threshold <= 0.0
                     {
                         self.state.output_image = Some(image_data);
-                        self.state.output_palette_sorted_indexed_image = None;
                         self.state.reduced_tile_count = self.state.base_tile_count;
                         self.state.tile_reduce_processing = false;
                     } else {
                         self.state.request_update_tile_reduce = true;
                         self.handle_tile_reduce_changes(ctx);
                     }
-                    self.state.output_palette_sorted_indexed_image = None;
+                    self.state.invalidate_palette_sort();
                     self.state.tile_count.last_count = None;
                     self.state.tile_count.mark_dirty();
                 }
@@ -197,7 +196,7 @@ impl QualetizeApp {
                     self.state.base_output_image = None;
                     self.state.base_tile_count = None;
                     self.state.reduced_tile_count = None;
-                    self.state.output_palette_sorted_indexed_image = None;
+                    self.state.invalidate_palette_sort();
                     self.state.tile_count.last_count = None;
                     self.state.tile_reduce_processing = false;
                     self.state.tile_count.mark_dirty();
@@ -243,7 +242,7 @@ impl QualetizeApp {
                         indexed_pixels: res.indexed_pixels,
                     });
                     self.state.output_image = Some(output);
-                    self.state.output_palette_sorted_indexed_image = None;
+                    self.state.invalidate_palette_sort();
                     self.state.reduced_tile_count = Self::count_tiles(
                         self.state.output_image.as_ref().unwrap(),
                         self.state.settings.tile_width,
@@ -306,8 +305,16 @@ impl QualetizeApp {
             return;
         };
 
-        self.state.output_image = Some(base.clone());
-        self.state.output_palette_sorted_indexed_image = None;
+        // Snapshot everything the worker needs before mutating state below.
+        let base_image = base.clone();
+        let reduce_input = base
+            .indexed
+            .as_ref()
+            .map(|indexed| (indexed.indexed_pixels.clone(), indexed.palettes.clone()));
+        let (base_width, base_height) = (base.width, base.height);
+
+        self.state.output_image = Some(base_image);
+        self.state.invalidate_palette_sort();
         self.state.reduced_tile_count = self.state.base_tile_count;
         self.state.tile_count.mark_dirty();
         if !self.state.settings.tile_reduce_post_enabled
@@ -317,7 +324,7 @@ impl QualetizeApp {
             return;
         }
 
-        let Some(indexed) = &base.indexed else {
+        let Some((indexed_pixels, palettes)) = reduce_input else {
             self.state.tile_reduce_processing = false;
             return;
         };
@@ -332,10 +339,10 @@ impl QualetizeApp {
         };
 
         let generation_id = self.image_processor.start_tile_reduce(
-            indexed.indexed_pixels.clone(),
-            indexed.palettes.clone(),
-            base.width,
-            base.height,
+            indexed_pixels,
+            palettes,
+            base_width,
+            base_height,
             opts,
         );
         self.state.tile_reduce_generation_id = generation_id;
@@ -608,36 +615,26 @@ impl QualetizeApp {
     }
 
     fn update_palette_sort_settings(&mut self) {
-        if self.state.output_palette_sorted_indexed_image.is_some()
-            && !self.state.palette_sort_settings_changed()
-        {
+        if !self.state.palette_sort_needs_update() {
             return;
         }
+        self.state.clear_palette_sort_dirty();
 
-        // Extract the indexed image data first to avoid borrowing conflicts
-        let indexed_image = if let Some(output_image) = &self.state.output_image {
-            if let Some(indexed) = &output_image.indexed {
-                indexed.clone()
-            } else {
-                return;
-            }
-        } else {
-            return;
-        };
-
-        let palette_sort_settings = self.state.palette_sort_settings.clone();
-
-        self.state.update_palette_sort_settings_tracking();
-
-        if palette_sort_settings.mode == SortMode::None {
+        let settings = self.state.palette_sort_settings.clone();
+        if settings.mode == SortMode::None {
             self.state.output_palette_sorted_indexed_image = None;
-        } else {
-            self.state.output_palette_sorted_indexed_image = Some(indexed_image.sorted(
-                palette_sort_settings.mode,
-                palette_sort_settings.order,
-                self.state.settings.col0_is_clear,
-            ));
+            return;
         }
+
+        let col0_is_clear = self.state.settings.col0_is_clear;
+        let sorted = self
+            .state
+            .output_image
+            .as_ref()
+            .and_then(|image| image.indexed.as_ref())
+            .map(|indexed| indexed.sorted(settings.mode, settings.order, col0_is_clear));
+
+        self.state.output_palette_sorted_indexed_image = sorted;
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,10 +271,17 @@ impl QualetizeApp {
     }
 
     fn apply_color_correct_image(&mut self, ctx: &egui::Context) {
-        if let Some(image) = &self.state.input_image {
-            let color_corrected_image = image.color_corrected(&self.state.color_correction, ctx);
-            self.state.color_corrected_image = Some(color_corrected_image);
-        }
+        let Some(image) = &self.state.input_image else {
+            return;
+        };
+
+        // With color correction off the input is passed through untouched, which
+        // also skips a full pixel pass and a texture upload.
+        self.state.color_corrected_image = Some(if self.state.color_correction.enabled {
+            image.color_corrected(&self.state.color_correction, ctx)
+        } else {
+            image.clone()
+        });
     }
 
     fn handle_tile_reduce_changes(&mut self, ctx: &egui::Context) {
@@ -497,10 +504,8 @@ impl QualetizeApp {
                             time: std::time::Instant::now(),
                         });
 
-                        if let Some(input_image) = &self.state.input_image {
-                            self.state.color_corrected_image = Some(
-                                input_image.color_corrected(&self.state.color_correction, ctx),
-                            );
+                        if self.state.input_image.is_some() {
+                            self.apply_color_correct_image(ctx);
                         } else {
                             self.state.color_corrected_image = None;
                         }
@@ -609,8 +614,9 @@ impl Drop for QualetizeApp {
 
 impl eframe::App for QualetizeApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        let image_processing =
-            self.image_processor.is_processing() || self.state.tile_reduce_processing;
+        // The Qualetized and Tile Reduced panels show their own spinners, so the
+        // two stages are tracked separately (`state.tile_reduce_processing`).
+        let qualetize_processing = self.image_processor.is_processing();
 
         // apply theme
         self.apply_theme(ctx);
@@ -691,7 +697,7 @@ impl eframe::App for QualetizeApp {
                 if self.state.input_path.is_none() {
                     draw_main_content(ui);
                 } else {
-                    draw_image_view(ui, &mut self.state, image_processing);
+                    draw_image_view(ui, &mut self.state, qualetize_processing);
                 }
             });
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -577,6 +577,8 @@ impl Drop for QualetizeApp {
     fn drop(&mut self) {
         // Cancel any ongoing processing
         self.image_processor.cancel_current_processing();
+        // Flush a change made in the last moments before quitting
+        self.state.save_session_now();
         log::debug!("QualetizeApp dropped, resources cleaned up");
     }
 }
@@ -622,8 +624,9 @@ impl eframe::App for QualetizeApp {
         // Handle export requests
         self.handle_requests(ctx);
 
-        // Save preferences
+        // Mirror preferences and settings to disk so they survive a restart
         self.state.check_and_save_preferences();
+        self.state.check_and_save_session(ctx);
 
         let mut settings_changed = false;
         let mut tile_reduce_changed = false;

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::exporter::{save_indexed_bmp, save_indexed_png, save_rgba_image};
 use crate::image_processor::ImageProcessor;
 use crate::settings_manager::SettingsBundle;
 use crate::types::ImageData;
-use crate::types::app_state::{AppStateRequest, AppearanceMode, QualetizeRequest};
+use crate::types::app_state::{AppStateRequest, AppearanceMode, ExportSource, QualetizeRequest};
 use crate::types::image::{ImageDataIndexed, SortMode, TileCountOptions};
 use crate::types::{AppState, ExportFormat};
 use crate::ui::{
@@ -349,6 +349,49 @@ impl QualetizeApp {
         ImageData::count_unique_tiles(indexed, image.width, image.height, tile_w, tile_h, options)
     }
 
+    /// Write `source` to `output_path` on a worker thread.
+    fn export_image(&self, source: ExportSource, format: ExportFormat, output_path: String) {
+        if source == ExportSource::ColorCorrected {
+            let Some(image) = &self.state.color_corrected_image else {
+                log::error!("Export failed: no color corrected image in memory");
+                return;
+            };
+            let rgba_data = image.rgba_data.clone();
+            let (width, height) = (image.width, image.height);
+
+            std::thread::spawn(move || {
+                match save_rgba_image(&output_path, &rgba_data, width, height, format) {
+                    Ok(()) => log::info!("Color corrected export completed: {output_path}"),
+                    Err(e) => log::error!("Color corrected export failed: {e}"),
+                }
+            });
+            return;
+        }
+
+        let Some((indexed, width, height)) = self.state.indexed_for_export(source) else {
+            log::error!("Export failed: no indexed image available for {source:?}");
+            return;
+        };
+
+        std::thread::spawn(move || {
+            let pixels = &indexed.indexed_pixels;
+            let palettes = &indexed.palettes;
+            let result = match format {
+                ExportFormat::Bmp => {
+                    save_indexed_bmp(&output_path, pixels, palettes, width, height)
+                }
+                ExportFormat::PngIndexed => {
+                    save_indexed_png(&output_path, pixels, palettes, width, height)
+                }
+                ExportFormat::Png => Err("indexed export needs an indexed format".to_string()),
+            };
+            match result {
+                Ok(()) => log::info!("Indexed export completed: {output_path}"),
+                Err(e) => log::error!("Indexed export failed: {e}"),
+            }
+        });
+    }
+
     /// Run a native file dialog on a worker thread so the UI keeps repainting,
     /// and feed whatever the user picked back into the request channel.
     ///
@@ -383,92 +426,12 @@ impl QualetizeApp {
                 });
                 self.state.update_color_correction_tracking();
             }
-            AppStateRequest::ColorCorrectedPng { output_path } => {
-                // Use ImageData pixels directly
-                let Some(color_corrected_image) = &self.state.color_corrected_image else {
-                    log::error!("No color corrected image data available in memory");
-                    return;
-                };
-
-                let output_path = output_path.clone();
-                let rgba_data = color_corrected_image.rgba_data.clone();
-                let width = color_corrected_image.width;
-                let height = color_corrected_image.height;
-                std::thread::spawn(move || {
-                    match save_rgba_image(
-                        &output_path,
-                        &rgba_data,
-                        width,
-                        height,
-                        crate::types::ExportFormat::Png,
-                    ) {
-                        Ok(()) => {
-                            log::info!(
-                                "Color corrected PNG export completed successfully (from memory)"
-                            );
-                        }
-                        Err(e) => {
-                            log::error!("Color corrected PNG export failed: {e}");
-                        }
-                    }
-                });
-            }
-            AppStateRequest::QualetizedIndexed {
-                output_path,
+            AppStateRequest::ExportImage {
+                source,
                 format,
+                output_path,
             } => {
-                let Some(output_image) = &self.state.output_image else {
-                    log::error!("Qualetized export failed: output image is None");
-                    return;
-                };
-
-                // Prefer the sorted palette when one is active.
-                let Some(indexed) = self
-                    .state
-                    .output_palette_sorted_indexed_image
-                    .as_ref()
-                    .or(output_image.indexed.as_ref())
-                else {
-                    return;
-                };
-
-                match format {
-                    crate::types::ExportFormat::Png => {
-                        log::error!("Qualetized export failed: Unexpected format");
-                    }
-                    crate::types::ExportFormat::Bmp => {
-                        match save_indexed_bmp(
-                            output_path,
-                            &indexed.indexed_pixels,
-                            &indexed.palettes,
-                            output_image.width,
-                            output_image.height,
-                        ) {
-                            Ok(()) => {
-                                log::info!("Qualetized indexed BMP export completed successfully");
-                            }
-                            Err(e) => {
-                                log::error!("Qualetized indexed export failed: {e}");
-                            }
-                        }
-                    }
-                    crate::types::ExportFormat::PngIndexed => {
-                        match save_indexed_png(
-                            output_path,
-                            &indexed.indexed_pixels,
-                            &indexed.palettes,
-                            output_image.width,
-                            output_image.height,
-                        ) {
-                            Ok(()) => {
-                                log::info!("Qualetized indexed PNG export completed successfully");
-                            }
-                            Err(e) => {
-                                log::error!("Qualetized indexed export failed: {e}");
-                            }
-                        }
-                    }
-                }
+                self.export_image(*source, *format, output_path.clone());
             }
             AppStateRequest::SaveSettings { path } => {
                 let settings_bundle = SettingsBundle::new(
@@ -530,12 +493,13 @@ impl QualetizeApp {
                     })
                 });
             }
-            AppStateRequest::ExportImageDialog { format, suffix } => {
+            AppStateRequest::ExportImageDialog { source, format } => {
                 let Some(input_path) = self.state.input_path.clone() else {
                     return;
                 };
-                let default_path = get_export_path(&input_path, format, suffix.as_deref());
-                let format = *format;
+                let (source, format) = (*source, *format);
+                let default_path =
+                    get_export_path(&input_path, &format, Some(source.file_suffix()));
 
                 self.spawn_file_dialog(move |dialog| {
                     let mut dialog = dialog.add_filter(
@@ -549,13 +513,10 @@ impl QualetizeApp {
                         dialog = dialog.set_directory(parent);
                     }
 
-                    let output_path = dialog.save_file()?.display().to_string();
-                    Some(match format {
-                        ExportFormat::Png => AppStateRequest::ColorCorrectedPng { output_path },
-                        _ => AppStateRequest::QualetizedIndexed {
-                            output_path,
-                            format,
-                        },
+                    Some(AppStateRequest::ExportImage {
+                        source,
+                        format,
+                        output_path: dialog.save_file()?.display().to_string(),
                     })
                 });
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -558,7 +558,7 @@ impl QualetizeApp {
                 self.spawn_file_dialog(|dialog| {
                     let path = settings_file_dialog(dialog)
                         .set_file_name("qualetize_settings.qset")
-                        .pick_file()?;
+                        .save_file()?;
                     Some(AppStateRequest::SaveSettings {
                         path: path.display().to_string(),
                     })

--- a/src/app.rs
+++ b/src/app.rs
@@ -445,7 +445,7 @@ impl QualetizeApp {
                 let settings_bundle = SettingsBundle::new(
                     self.state.settings.clone(),
                     self.state.color_correction.clone(),
-                    self.state.palette_sort_settings.clone(),
+                    self.state.palette_sort_settings,
                 );
 
                 match settings_bundle.save_to_file(path) {
@@ -515,7 +515,7 @@ impl QualetizeApp {
                     return;
                 };
                 let default_path = get_export_path(&input_path, format, suffix.as_deref());
-                let format_clone = format.clone();
+                let format_clone = *format;
 
                 let dialog_flag = self.state.file_dialog_open.clone();
                 std::thread::spawn(move || {
@@ -598,7 +598,7 @@ impl QualetizeApp {
         }
         self.state.clear_palette_sort_dirty();
 
-        let settings = self.state.palette_sort_settings.clone();
+        let settings = self.state.palette_sort_settings;
         if settings.mode == SortMode::None {
             self.state.output_palette_sorted_indexed_image = None;
             return;

--- a/src/app.rs
+++ b/src/app.rs
@@ -536,7 +536,7 @@ impl QualetizeApp {
                 let Some(input_path) = self.state.input_path.clone() else {
                     return;
                 };
-                let default_path = get_export_path(input_path, format, suffix.clone());
+                let default_path = get_export_path(&input_path, format, suffix.as_deref());
                 let format_clone = format.clone();
 
                 let dialog_flag = self.state.file_dialog_open.clone();
@@ -753,21 +753,29 @@ impl eframe::App for QualetizeApp {
     }
 }
 
+/// Build the default export path for `input_path`.
+///
+/// The extension is appended rather than set via [`std::path::Path::with_extension`],
+/// which would treat everything after the last dot of the *new* name as an extension
+/// and silently truncate it (`hero.idle.png` -> `hero.png`).
 fn get_export_path(
-    input_path: String,
+    input_path: &str,
     format: &ExportFormat,
-    suffix: Option<String>,
+    suffix: Option<&str>,
 ) -> std::path::PathBuf {
-    let path = Path::new(&input_path);
+    let path = Path::new(input_path);
 
     let parent = path.parent().unwrap_or(Path::new("."));
-    let stem = path.file_stem().unwrap_or(std::ffi::OsStr::new("output"));
-    let new_name = if let Some(suffix) = suffix {
-        format!("{}_{}", stem.to_string_lossy(), suffix)
-    } else {
-        stem.to_string_lossy().to_string()
+    let stem = path
+        .file_stem()
+        .unwrap_or(std::ffi::OsStr::new("output"))
+        .to_string_lossy();
+    let extension = format.extension();
+    let file_name = match suffix {
+        Some(suffix) => format!("{stem}_{suffix}.{extension}"),
+        None => format!("{stem}.{extension}"),
     };
-    parent.join(new_name).with_extension(format.extension())
+    parent.join(file_name)
 }
 
 pub struct FileDialogGuard {
@@ -785,5 +793,66 @@ impl Drop for FileDialogGuard {
     fn drop(&mut self) {
         self.flag.store(false, Ordering::Relaxed);
         log::debug!("FileDialogGuard dropped - dialog closed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn export_path(input: &str, format: ExportFormat, suffix: Option<&str>) -> String {
+        get_export_path(input, &format, suffix)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn export_path_appends_suffix_and_extension() {
+        assert_eq!(
+            export_path(
+                "/img/hero.png",
+                ExportFormat::PngIndexed,
+                Some("qualetized")
+            ),
+            "/img/hero_qualetized.png"
+        );
+        assert_eq!(
+            export_path("/img/hero.png", ExportFormat::Bmp, Some("qualetized")),
+            "/img/hero_qualetized.bmp"
+        );
+    }
+
+    #[test]
+    fn export_path_without_suffix_keeps_stem() {
+        assert_eq!(
+            export_path("/img/hero.png", ExportFormat::Bmp, None),
+            "/img/hero.bmp"
+        );
+    }
+
+    /// Regression: `with_extension` used to reduce `hero.idle.png` to `hero.png`,
+    /// dropping both the suffix and part of the original file name.
+    #[test]
+    fn export_path_preserves_dots_in_file_name() {
+        assert_eq!(
+            export_path(
+                "/img/hero.idle.png",
+                ExportFormat::PngIndexed,
+                Some("qualetized")
+            ),
+            "/img/hero.idle_qualetized.png"
+        );
+        assert_eq!(
+            export_path("/img/tile.v2.bmp", ExportFormat::Bmp, None),
+            "/img/tile.v2.bmp"
+        );
+    }
+
+    #[test]
+    fn export_path_handles_missing_extension_and_parent() {
+        assert_eq!(
+            export_path("hero", ExportFormat::Bmp, Some("qualetized")),
+            "hero_qualetized.bmp"
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -639,7 +639,9 @@ impl eframe::App for QualetizeApp {
             egui::Frame::NONE
                 .inner_margin(Margin::symmetric(0, 4))
                 .show(ui, |ui| {
-                    settings_changed |= draw_header(ui, &mut self.state);
+                    let (settings, tile_reduce) = draw_header(ui, &mut self.state);
+                    settings_changed |= settings;
+                    tile_reduce_changed |= tile_reduce;
                 });
         });
 

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -10,41 +10,44 @@ impl ColorProcessor {
         height: u32,
         corrections: &ColorCorrection,
     ) -> RgbaImage {
-        let mut output = ImageBuffer::new(width, height);
-        for i in (0..pixels.len()).step_by(4) {
-            let r = pixels[i];
-            let g = pixels[i + 1];
-            let b = pixels[i + 2];
-            let a = pixels[i + 3];
+        let tone_curve = Self::tone_curve(corrections);
+        let mut output: RgbaImage = ImageBuffer::new(width, height);
 
-            let corrected = Self::apply_pixel_corrections(&Rgba([r, g, b, a]), corrections);
-            output.put_pixel(i as u32 / 4 % width, i as u32 / 4 / width, corrected);
+        // chunks_exact and pixels_mut walk the buffers in the same row-major
+        // order, so no per-pixel coordinate arithmetic is needed.
+        for (source, target) in pixels.chunks_exact(4).zip(output.pixels_mut()) {
+            *target = Self::apply_pixel_corrections(
+                &Rgba([source[0], source[1], source[2], source[3]]),
+                corrections,
+                &tone_curve,
+            );
         }
+
         output
     }
 
-    fn apply_pixel_corrections(pixel: &Rgba<u8>, corrections: &ColorCorrection) -> Rgba<u8> {
+    /// Gamma, brightness and contrast are applied per channel and depend only on
+    /// the input byte, so they collapse into a single 256 entry table. The table
+    /// is bit-exact with the per-pixel computation because the input is always
+    /// `i as f32 / 255.0`.
+    fn tone_curve(corrections: &ColorCorrection) -> [f32; 256] {
+        std::array::from_fn(|i| {
+            let value = Self::apply_gamma(i as f32 / 255.0, corrections.gamma);
+            Self::apply_contrast(value + corrections.brightness, corrections.contrast)
+        })
+    }
+
+    fn apply_pixel_corrections(
+        pixel: &Rgba<u8>,
+        corrections: &ColorCorrection,
+        tone_curve: &[f32; 256],
+    ) -> Rgba<u8> {
         let [r, g, b, a] = pixel.0;
 
-        // Convert to float 0.0-1.0 range
-        let mut rf = r as f32 / 255.0;
-        let mut gf = g as f32 / 255.0;
-        let mut bf = b as f32 / 255.0;
-
-        // Apply gamma correction first
-        rf = Self::apply_gamma(rf, corrections.gamma);
-        gf = Self::apply_gamma(gf, corrections.gamma);
-        bf = Self::apply_gamma(bf, corrections.gamma);
-
-        // Apply brightness
-        rf += corrections.brightness;
-        gf += corrections.brightness;
-        bf += corrections.brightness;
-
-        // Apply contrast
-        rf = Self::apply_contrast(rf, corrections.contrast);
-        gf = Self::apply_contrast(gf, corrections.contrast);
-        bf = Self::apply_contrast(bf, corrections.contrast);
+        // Gamma, brightness and contrast in one table lookup per channel
+        let rf = tone_curve[r as usize];
+        let gf = tone_curve[g as usize];
+        let bf = tone_curve[b as usize];
 
         // Convert to HSV for saturation and hue adjustments
         let (mut h, mut s, v) = Self::rgb_to_hsv(rf, gf, bf);
@@ -172,4 +175,94 @@ pub fn format_percentage(value: f32) -> String {
 
 pub fn format_gamma(gamma: f32) -> String {
     format!("{gamma:.2}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn presets() -> [ColorCorrection; 5] {
+        [
+            ColorCorrection::default(),
+            ColorCorrection::preset_vibrant(),
+            ColorCorrection::preset_retro_warm(),
+            ColorCorrection::preset_retro_cool(),
+            ColorCorrection::preset_dark(),
+        ]
+    }
+
+    /// The lookup table replaced three per-pixel operations; it has to produce
+    /// bit-identical results, not merely close ones.
+    #[test]
+    fn tone_curve_is_bit_exact_with_the_per_pixel_computation() {
+        for corrections in presets() {
+            let curve = ColorProcessor::tone_curve(&corrections);
+            for value in 0..=255usize {
+                let mut expected = value as f32 / 255.0;
+                expected = ColorProcessor::apply_gamma(expected, corrections.gamma);
+                expected += corrections.brightness;
+                expected = ColorProcessor::apply_contrast(expected, corrections.contrast);
+
+                assert_eq!(
+                    curve[value].to_bits(),
+                    expected.to_bits(),
+                    "gamma {} value {value}",
+                    corrections.gamma
+                );
+            }
+        }
+    }
+
+    /// chunks_exact/pixels_mut must visit the buffers in the same order as the
+    /// coordinate arithmetic it replaced.
+    #[test]
+    fn corrected_pixels_land_at_the_right_coordinates() {
+        let (width, height) = (3u32, 2u32);
+        let pixels: Vec<u8> = (0..(width * height * 4) as u8).map(|i| i * 7).collect();
+        let corrections = ColorCorrection::preset_vibrant();
+        let curve = ColorProcessor::tone_curve(&corrections);
+
+        let output = ColorProcessor::apply_pixels_correction(&pixels, width, height, &corrections);
+
+        for y in 0..height {
+            for x in 0..width {
+                let i = ((y * width + x) * 4) as usize;
+                let expected = ColorProcessor::apply_pixel_corrections(
+                    &Rgba([pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]),
+                    &corrections,
+                    &curve,
+                );
+                assert_eq!(*output.get_pixel(x, y), expected, "at ({x}, {y})");
+            }
+        }
+    }
+
+    #[test]
+    fn alpha_is_preserved() {
+        let pixels = vec![10, 20, 30, 40, 50, 60, 70, 200];
+        let output =
+            ColorProcessor::apply_pixels_correction(&pixels, 2, 1, &ColorCorrection::preset_dark());
+
+        assert_eq!(output.get_pixel(0, 0).0[3], 40);
+        assert_eq!(output.get_pixel(1, 0).0[3], 200);
+    }
+
+    #[test]
+    fn hsv_round_trip_is_stable() {
+        for (r, g, b) in [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (0.2, 0.6, 0.9)] {
+            let (h, s, v) = ColorProcessor::rgb_to_hsv(r, g, b);
+            let (r2, g2, b2) = ColorProcessor::hsv_to_rgb(h, s, v);
+            assert!((r - r2).abs() < 1e-5, "{r} vs {r2}");
+            assert!((g - g2).abs() < 1e-5, "{g} vs {g2}");
+            assert!((b - b2).abs() < 1e-5, "{b} vs {b2}");
+        }
+    }
+
+    #[test]
+    fn gamma_display_conversion_round_trips() {
+        for gamma in [0.1, 0.5, 1.0, 2.0, 3.0] {
+            let display = gamma_to_display_value(gamma);
+            assert!((display_value_to_gamma(display) - gamma).abs() < 1e-4);
+        }
+    }
 }

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -197,14 +197,14 @@ mod tests {
     fn tone_curve_is_bit_exact_with_the_per_pixel_computation() {
         for corrections in presets() {
             let curve = ColorProcessor::tone_curve(&corrections);
-            for value in 0..=255usize {
+            for (value, entry) in curve.iter().enumerate() {
                 let mut expected = value as f32 / 255.0;
                 expected = ColorProcessor::apply_gamma(expected, corrections.gamma);
                 expected += corrections.brightness;
                 expected = ColorProcessor::apply_contrast(expected, corrections.contrast);
 
                 assert_eq!(
-                    curve[value].to_bits(),
+                    entry.to_bits(),
                     expected.to_bits(),
                     "gamma {} value {value}",
                     corrections.gamma

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -85,10 +85,12 @@ impl ColorProcessor {
         gf = gf.clamp(0.0, 1.0);
         bf = bf.clamp(0.0, 1.0);
 
+        // Round rather than truncate: truncation biased every channel downwards,
+        // so even a neutral correction could shift a value by one.
         Rgba([
-            (rf * 255.0) as u8,
-            (gf * 255.0) as u8,
-            (bf * 255.0) as u8,
+            (rf * 255.0).round() as u8,
+            (gf * 255.0).round() as u8,
+            (bf * 255.0).round() as u8,
             a, // Keep original alpha
         ])
     }

--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -55,13 +55,7 @@ pub struct TileReduceResult {
 
 impl ImageProcessor {
     pub fn new() -> Self {
-        Self {
-            tile_reduce_thread: None,
-            tile_reduce_receiver: None,
-            tile_reduce_generation_id: 0,
-            tile_reduce_cancel: None,
-            ..Default::default()
-        }
+        Self::default()
     }
 
     pub fn start_qualetize(
@@ -72,15 +66,10 @@ impl ImageProcessor {
         // Cancel any existing processing
         self.cancel_current_processing();
 
-        // Pre-generate BGRA data to improve responsiveness and avoid redundancy
-        let bgra_result = self.generate_bgra_data(color_corrected_image);
-        let (bgra_data, width, height) = match bgra_result {
-            Ok(data) => data,
-            Err(e) => {
-                log::error!("Failed to generate BGRA data: {e}");
-                return;
-            }
-        };
+        // Convert up front so the worker thread starts on data it can use directly.
+        let bgra_data = to_bgra(&color_corrected_image.rgba_data);
+        let width = color_corrected_image.width;
+        let height = color_corrected_image.height;
 
         let (result_sender, result_receiver) = mpsc::channel();
         let (cancel_sender, cancel_receiver) = mpsc::channel();
@@ -103,29 +92,6 @@ impl ImageProcessor {
         self.preview_thread = Some(thread);
     }
 
-    pub fn generate_bgra_data(
-        &mut self,
-        color_corrected_image: &ImageData,
-    ) -> Result<(Vec<BGRA8>, u32, u32), String> {
-        // Convert to BGRA
-        let width = color_corrected_image.width;
-        let height = color_corrected_image.height;
-
-        let input_data = &color_corrected_image.rgba_data;
-
-        // Convert RGBA to BGRA for qualetize
-        let mut bgra_data: Vec<BGRA8> = Vec::with_capacity((width * height) as usize);
-        for chunk in input_data.chunks_exact(4) {
-            bgra_data.push(BGRA8 {
-                b: chunk[2],
-                g: chunk[1],
-                r: chunk[0],
-                a: chunk[3],
-            });
-        }
-        Ok((bgra_data, width, height))
-    }
-
     pub fn check_preview_complete(&mut self, ctx: &Context) -> Option<Result<ImageData, String>> {
         self.cleanup_finished_threads();
 
@@ -135,34 +101,29 @@ impl ImageProcessor {
             self.preview_thread = None;
             self.preview_receiver = None;
 
-            return Some(match result {
+            return match result {
                 Ok(qualetize_result) => {
-                    if qualetize_result.generation_id == self.current_generation_id {
-                        log::debug!(
-                            "Accepting result from generation {}",
-                            qualetize_result.generation_id
-                        );
-                        match ImageData::create_from_qualetize_result(qualetize_result, ctx) {
-                            Ok(image_data) => Ok(image_data),
-                            Err(e) => Err(e),
-                        }
-                    } else {
+                    if qualetize_result.generation_id != self.current_generation_id {
                         log::debug!(
                             "Ignoring outdated result from generation {} (current: {})",
                             qualetize_result.generation_id,
                             self.current_generation_id
                         );
-                        return None; // 古い結果は無視
+                        return None;
                     }
+                    log::debug!(
+                        "Accepting result from generation {}",
+                        qualetize_result.generation_id
+                    );
+                    Some(ImageData::create_from_qualetize_result(
+                        qualetize_result,
+                        ctx,
+                    ))
                 }
-                Err(e) => {
-                    if e.contains("Processing cancelled") {
-                        return None; // キャンセルされた処理は無視
-                    } else {
-                        Err(e)
-                    }
-                }
-            });
+                // A cancelled run is not a failure worth reporting.
+                Err(e) if e.contains("Processing cancelled") => None,
+                Err(e) => Some(Err(e)),
+            };
         }
         None
     }
@@ -184,23 +145,20 @@ impl ImageProcessor {
 
     pub fn cancel_current_processing(&mut self) {
         if let Some(cancel_sender) = &self.cancel_sender {
-            let _ = cancel_sender.send(()); // キャンセル信号を送信
+            let _ = cancel_sender.send(());
         }
 
-        // 古いスレッドをバックグラウンドで実行継続させる（結果は無視）
+        // Let the old thread run to completion in the background; its result is
+        // discarded because the generation ID below no longer matches.
         if let Some(old_thread) = self.preview_thread.take() {
             self.active_threads.push(old_thread);
         }
 
-        // 現在の処理をクリア
         self.preview_thread = None;
         self.preview_receiver = None;
         self.cancel_sender = None;
-
-        // 世代IDを更新（古い結果を無視するため）
         self.current_generation_id += 1;
 
-        // 完了した古いスレッドをクリーンアップ
         self.cleanup_finished_threads();
     }
 
@@ -717,4 +675,16 @@ impl Orientation {
 struct OrientationMap {
     orientation: Orientation,
     map: Vec<usize>,
+}
+
+/// Qualetize consumes BGRA, egui produces RGBA.
+fn to_bgra(rgba: &[u8]) -> Vec<BGRA8> {
+    rgba.chunks_exact(4)
+        .map(|px| BGRA8 {
+            b: px[2],
+            g: px[1],
+            r: px[0],
+            a: px[3],
+        })
+        .collect()
 }

--- a/src/settings_manager/mod.rs
+++ b/src/settings_manager/mod.rs
@@ -28,6 +28,13 @@ impl SettingsBundle {
         }
     }
 
+    /// Compare the settings only; `version` is metadata about the writer.
+    pub fn matches(&self, other: &Self) -> bool {
+        self.qualetize_settings == other.qualetize_settings
+            && self.color_correction == other.color_correction
+            && self.sort_settings == other.sort_settings
+    }
+
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
         let json_data = serde_json::to_string_pretty(self)
             .map_err(|e| format!("Failed to serialize settings: {e}"))?;
@@ -65,11 +72,94 @@ impl SettingsBundle {
     pub fn get_settings_file_extension() -> &'static str {
         "qset"
     }
+
+    /// Where the settings in use are mirrored so they survive a restart.
+    /// Same format as a hand-saved `.qset`, so it can be inspected or reused.
+    pub fn session_path() -> Option<std::path::PathBuf> {
+        Some(
+            dirs::config_dir()?
+                .join("QualetizeGUI")
+                .join("session.qset"),
+        )
+    }
+
+    /// Restore the settings from the last run, falling back to the defaults.
+    pub fn load_session() -> Self {
+        let bundle = Self::session_path().and_then(|path| Self::load_from_file(path).ok());
+
+        bundle.unwrap_or_else(|| {
+            Self::new(
+                QualetizeSettings::default(),
+                ColorCorrection::default(),
+                PaletteSortSettings::default(),
+            )
+        })
+    }
+
+    pub fn save_session(&self) -> Result<(), String> {
+        let path = Self::session_path().ok_or("Could not determine config directory")?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create config directory: {e}"))?;
+        }
+        self.save_to_file(path)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn matches_ignores_the_writer_version() {
+        let a = SettingsBundle::new(
+            QualetizeSettings::default(),
+            ColorCorrection::default(),
+            PaletteSortSettings::default(),
+        );
+        let mut b = a.clone();
+        b.version = "0.0.0-other".to_string();
+        assert!(a.matches(&b));
+
+        b.qualetize_settings.tile_width = 16;
+        assert!(!a.matches(&b));
+    }
+
+    #[test]
+    fn matches_notices_a_color_correction_change() {
+        let a = SettingsBundle::new(
+            QualetizeSettings::default(),
+            ColorCorrection::default(),
+            PaletteSortSettings::default(),
+        );
+        let mut b = a.clone();
+        b.color_correction.enabled = !b.color_correction.enabled;
+        assert!(!a.matches(&b));
+    }
+
+    /// A session file written before a field existed still has to load.
+    #[test]
+    fn a_session_missing_newer_fields_still_loads() {
+        let json = r#"{
+            "qualetize_settings": {
+                "tile_width": 8, "tile_height": 8, "n_palettes": 1, "n_colors": 16,
+                "rgba_depth": "3331", "premul_alpha": false, "color_space": "RgbLinear",
+                "dither_mode": "Floyd", "dither_level": 0.5, "tile_passes": 1000,
+                "color_passes": 100, "col0_is_clear": false, "clear_color": "None"
+            },
+            "color_correction": {
+                "brightness": 0.0, "contrast": 1.0, "gamma": 1.0, "saturation": 1.0,
+                "hue_shift": 0.0, "shadows": 0.0, "highlights": 0.0
+            },
+            "version": "0.4.0"
+        }"#;
+
+        let bundle: SettingsBundle = serde_json::from_str(json).expect("loads");
+        assert_eq!(bundle.qualetize_settings.tile_width, 8);
+        // Predates the flag, and back then correction was always applied.
+        assert!(bundle.color_correction.enabled);
+        assert_eq!(bundle.sort_settings, PaletteSortSettings::default());
+    }
 
     #[test]
     fn test_settings_serialization() {

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, atomic::AtomicBool, mpsc};
 use super::{
     color_correction::ColorCorrection,
     export::ExportFormat,
-    image::{ImageData, ImageDataIndexed, PaletteSortSettings},
+    image::{ImageData, ImageDataIndexed, PaletteSortSettings, SortMode},
     preferences::UserPreferences,
     qualetize::QualetizeSettings,
 };
@@ -66,18 +66,38 @@ impl TileCountState {
     }
 }
 
+/// Which stage of the pipeline an export refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportSource {
+    /// The input image after color correction, in full color.
+    ColorCorrected,
+    /// The indexed quantization result, before tile reduction.
+    Qualetized,
+    /// The indexed result after the tile reduction pass.
+    TileReduced,
+}
+
+impl ExportSource {
+    /// Appended to the input file name to build the default export name.
+    pub fn file_suffix(self) -> &'static str {
+        match self {
+            Self::ColorCorrected => "color_corrected",
+            Self::Qualetized => "qualetized",
+            Self::TileReduced => "tile_reduced",
+        }
+    }
+}
+
 // Export request types
 #[derive(Debug, Clone)]
 pub enum AppStateRequest {
     LoadImage {
         path: String,
     },
-    ColorCorrectedPng {
-        output_path: String,
-    },
-    QualetizedIndexed {
-        output_path: String,
+    ExportImage {
+        source: ExportSource,
         format: ExportFormat,
+        output_path: String,
     },
     SaveSettings {
         path: String,
@@ -88,8 +108,8 @@ pub enum AppStateRequest {
 
     OpenImageDialog,
     ExportImageDialog {
+        source: ExportSource,
         format: ExportFormat,
-        suffix: Option<String>,
     },
     SaveSettingsDialog,
     LoadSettingsDialog,
@@ -267,6 +287,43 @@ impl AppState {
         self.request_update_tile_reduce = false;
         self.invalidate_palette_sort();
         self.tile_count.reset();
+    }
+
+    /// Whether `source` currently has something to export. The optional passes
+    /// are only offered while they are enabled, so the menu entry matches the
+    /// view it refers to.
+    pub fn can_export(&self, source: ExportSource) -> bool {
+        match source {
+            ExportSource::ColorCorrected => {
+                self.color_correction.enabled && self.color_corrected_image.is_some()
+            }
+            ExportSource::Qualetized => self.base_output_image.is_some(),
+            ExportSource::TileReduced => {
+                self.settings.tile_reduce_post_enabled && self.output_image.is_some()
+            }
+        }
+    }
+
+    /// The indexed image to export for `source`, with the current palette sort
+    /// applied. Sorting is redone here rather than reusing
+    /// `output_palette_sorted_indexed_image`, which only ever describes the
+    /// final image and would be wrong for the pre-reduction export.
+    pub fn indexed_for_export(&self, source: ExportSource) -> Option<(ImageDataIndexed, u32, u32)> {
+        let image = match source {
+            ExportSource::Qualetized => self.base_output_image.as_ref()?,
+            ExportSource::TileReduced => self.output_image.as_ref()?,
+            ExportSource::ColorCorrected => return None,
+        };
+        let indexed = image.indexed.as_ref()?;
+
+        let sort = self.palette_sort_settings;
+        let indexed = if sort.mode == SortMode::None {
+            indexed.clone()
+        } else {
+            indexed.sorted(sort.mode, sort.order, self.settings.col0_is_clear)
+        };
+
+        Some((indexed, image.width, image.height))
     }
 
     /// Drop the loaded image together with everything derived from it.

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -239,7 +239,7 @@ impl AppState {
 
     /// Mark the sorted palette as up to date with the current settings.
     pub fn clear_palette_sort_dirty(&mut self) {
-        self.last_palette_sort_settings = self.palette_sort_settings.clone();
+        self.last_palette_sort_settings = self.palette_sort_settings;
         self.palette_sort_dirty = false;
     }
 

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -8,6 +8,7 @@ use super::{
     preferences::UserPreferences,
     qualetize::QualetizeSettings,
 };
+use crate::settings_manager::SettingsBundle;
 use crate::types::image::TileCountOptions;
 use std::time::Instant;
 
@@ -147,6 +148,10 @@ pub struct AppState {
 
     // Qualetize Settings
     pub settings: QualetizeSettings,
+    /// Snapshot of what is mirrored to the session file, so it is only rewritten
+    /// when something actually changed.
+    last_saved_session: SettingsBundle,
+    session_save_deadline: Option<Instant>,
     pub request_update_qualetized_image: Option<QualetizeRequest>,
     pub request_update_tile_reduce: bool,
     pub debounce_delay: std::time::Duration,
@@ -198,6 +203,7 @@ pub struct FittedInput {
 impl Default for AppState {
     fn default() -> Self {
         let preferences = UserPreferences::load();
+        let session = SettingsBundle::load_session();
         let (sender, receiver) = mpsc::channel();
 
         Self {
@@ -220,16 +226,18 @@ impl Default for AppState {
             preferences: preferences.clone(),
             last_preferences: preferences.clone(),
 
-            settings: QualetizeSettings::default(),
+            settings: session.qualetize_settings.clone(),
+            last_saved_session: session.clone(),
+            session_save_deadline: None,
             request_update_qualetized_image: None,
             request_update_tile_reduce: false,
             debounce_delay: std::time::Duration::from_millis(100),
 
-            last_color_correction: ColorCorrection::default(),
-            color_correction: ColorCorrection::default(),
+            last_color_correction: session.color_correction.clone(),
+            color_correction: session.color_correction.clone(),
 
-            palette_sort_settings: PaletteSortSettings::default(),
-            last_palette_sort_settings: PaletteSortSettings::default(),
+            palette_sort_settings: session.sort_settings,
+            last_palette_sort_settings: session.sort_settings,
             palette_sort_dirty: false,
 
             tile_count: TileCountState::default(),
@@ -265,6 +273,54 @@ impl AppState {
             self.settings.tile_width,
             self.settings.tile_height,
         ))
+    }
+
+    /// Take the settings currently in use as a bundle, for saving.
+    pub fn settings_bundle(&self) -> SettingsBundle {
+        SettingsBundle::new(
+            self.settings.clone(),
+            self.color_correction.clone(),
+            self.palette_sort_settings,
+        )
+    }
+
+    /// Mirror the settings to the session file so they survive a restart.
+    ///
+    /// Writes are held back briefly so dragging a slider does not hit the disk
+    /// on every frame. A repaint is scheduled for the deadline so the write
+    /// still happens when nothing else asks for a frame.
+    pub fn check_and_save_session(&mut self, ctx: &egui::Context) {
+        const SAVE_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(750);
+
+        if self.settings_bundle().matches(&self.last_saved_session) {
+            self.session_save_deadline = None;
+            return;
+        }
+
+        let deadline = *self
+            .session_save_deadline
+            .get_or_insert_with(|| Instant::now() + SAVE_DEBOUNCE);
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            self.save_session_now();
+        } else {
+            ctx.request_repaint_after(remaining);
+        }
+    }
+
+    /// Write a pending change straight away, for shutdown.
+    pub fn save_session_now(&mut self) {
+        let current = self.settings_bundle();
+        self.session_save_deadline = None;
+        if current.matches(&self.last_saved_session) {
+            return;
+        }
+
+        if let Err(e) = current.save_session() {
+            log::error!("Failed to save session settings: {e}");
+        }
+        self.last_saved_session = current;
     }
 
     pub fn check_and_save_preferences(&mut self) {

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -126,6 +126,10 @@ pub struct AppState {
     // Palette Sort Settings
     pub palette_sort_settings: PaletteSortSettings,
     last_palette_sort_settings: PaletteSortSettings,
+    /// Set when the source of the sorted palette changed and it has to be recomputed.
+    /// `output_palette_sorted_indexed_image` cannot be used for this on its own, because
+    /// `None` is also the legitimate result of `SortMode::None`.
+    palette_sort_dirty: bool,
 
     pub tile_count: TileCountState,
 
@@ -178,6 +182,7 @@ impl Default for AppState {
 
             palette_sort_settings: PaletteSortSettings::default(),
             last_palette_sort_settings: PaletteSortSettings::default(),
+            palette_sort_dirty: false,
 
             tile_count: TileCountState::default(),
 
@@ -214,13 +219,21 @@ impl AppState {
         }
     }
 
-    pub fn palette_sort_settings_changed(&self) -> bool {
-        self.palette_sort_settings != self.last_palette_sort_settings
+    /// Drop the cached sorted palette and schedule a recomputation.
+    /// Call this whenever `output_image` (or anything `sorted()` reads) changes.
+    pub fn invalidate_palette_sort(&mut self) {
+        self.output_palette_sorted_indexed_image = None;
+        self.palette_sort_dirty = true;
     }
 
-    /// Update the tracked color correction settings
-    pub fn update_palette_sort_settings_tracking(&mut self) {
+    pub fn palette_sort_needs_update(&self) -> bool {
+        self.palette_sort_dirty || self.palette_sort_settings != self.last_palette_sort_settings
+    }
+
+    /// Mark the sorted palette as up to date with the current settings.
+    pub fn clear_palette_sort_dirty(&mut self) {
         self.last_palette_sort_settings = self.palette_sort_settings.clone();
+        self.palette_sort_dirty = false;
     }
 
     /// Check if color correction settings have changed

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -132,7 +132,12 @@ pub struct AppState {
     pub reduced_tile_count: Option<usize>,
     pub tile_reduce_processing: bool,
     pub tile_reduce_generation_id: u64,
-    pub tile_reduce_toast: Option<TileReduceToast>,
+    pub tile_reduce_toast: Option<Toast>,
+
+    /// Set only while the loaded image needs extending; the input image itself
+    /// is never modified, so a later tile size change re-derives this from it.
+    pub tile_fitted_input: Option<FittedInput>,
+    pub tile_fit_toast: Option<Toast>,
 
     // View Settings
     pub zoom: f32,
@@ -160,9 +165,6 @@ pub struct AppState {
 
     pub tile_count: TileCountState,
 
-    // warning
-    pub tile_size_warning: bool,
-
     // Export requests
     pub app_state_request_receiver: mpsc::Receiver<AppStateRequest>,
     pub app_state_request_sender: mpsc::Sender<AppStateRequest>,
@@ -170,10 +172,27 @@ pub struct AppState {
     pub file_dialog_open: Arc<AtomicBool>,
 }
 
+/// A short lived message drawn over an image panel.
 #[derive(Clone)]
-pub struct TileReduceToast {
+pub struct Toast {
     pub message: String,
     pub time: Instant,
+}
+
+impl Toast {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            time: Instant::now(),
+        }
+    }
+}
+
+/// The input image extended so its size is a multiple of the tile size.
+pub struct FittedInput {
+    pub image: ImageData,
+    /// Size of the image as it was loaded, for the notice in the Original view.
+    pub original_size: (u32, u32),
 }
 
 impl Default for AppState {
@@ -193,6 +212,8 @@ impl Default for AppState {
             tile_reduce_processing: false,
             tile_reduce_generation_id: 0,
             tile_reduce_toast: None,
+            tile_fitted_input: None,
+            tile_fit_toast: None,
 
             zoom: 1.0,
             pan_offset: Vec2::ZERO,
@@ -213,8 +234,6 @@ impl Default for AppState {
 
             tile_count: TileCountState::default(),
 
-            tile_size_warning: false,
-
             app_state_request_receiver: receiver,
             app_state_request_sender: sender,
 
@@ -224,17 +243,28 @@ impl Default for AppState {
 }
 
 impl AppState {
-    pub fn tile_size_warning_message(&self) -> String {
-        let Some(input_image) = &self.input_image else {
-            return String::new();
-        };
-        format!(
-            "Image size ({}×{}) is not divisible by tile size ({}×{}). Qualetize processing cannot proceed.",
-            input_image.width,
-            input_image.height,
+    /// The image the pipeline actually runs on: the extended one when the
+    /// loaded image does not line up with the tile grid, otherwise the input.
+    pub fn processing_input(&self) -> Option<&ImageData> {
+        self.tile_fitted_input
+            .as_ref()
+            .map(|fitted| &fitted.image)
+            .or(self.input_image.as_ref())
+    }
+
+    /// Notice shown in the Original view while the image is being extended.
+    pub fn tile_fit_notice(&self) -> Option<String> {
+        let fitted = self.tile_fitted_input.as_ref()?;
+        let (from_w, from_h) = fitted.original_size;
+        Some(format!(
+            "⚠ Extended {}×{} → {}×{} to fit {}×{} tiles",
+            from_w,
+            from_h,
+            fitted.image.width,
+            fitted.image.height,
             self.settings.tile_width,
             self.settings.tile_height,
-        )
+        ))
     }
 
     pub fn check_and_save_preferences(&mut self) {
@@ -330,6 +360,8 @@ impl AppState {
     pub fn reset_all_images(&mut self) {
         self.input_path = None;
         self.input_image = None;
+        self.tile_fitted_input = None;
+        self.tile_fit_toast = None;
         self.color_corrected_image = None;
         self.reset_qualetize_outputs();
     }

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -54,7 +54,14 @@ impl TileCountState {
         }
     }
 
+    /// Force a recount on the next draw, keeping the stale number visible until then.
     pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    /// Force a recount and clear the displayed number, for when the image itself is gone.
+    pub fn reset(&mut self) {
+        self.last_count = None;
         self.dirty = true;
     }
 }
@@ -248,5 +255,25 @@ impl AppState {
 
     pub fn reset_view_settings(&mut self) {
         self.preferences = UserPreferences::default();
+    }
+
+    /// Drop the qualetize result and everything derived from it, keeping the
+    /// input and color corrected images.
+    pub fn reset_qualetize_outputs(&mut self) {
+        self.base_output_image = None;
+        self.output_image = None;
+        self.base_tile_count = None;
+        self.reduced_tile_count = None;
+        self.request_update_tile_reduce = false;
+        self.invalidate_palette_sort();
+        self.tile_count.reset();
+    }
+
+    /// Drop the loaded image together with everything derived from it.
+    pub fn reset_all_images(&mut self) {
+        self.input_path = None;
+        self.input_image = None;
+        self.color_corrected_image = None;
+        self.reset_qualetize_outputs();
     }
 }

--- a/src/types/color_correction.rs
+++ b/src/types/color_correction.rs
@@ -2,6 +2,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ColorCorrection {
+    /// When off the input image is passed through untouched, the settings are
+    /// hidden and no "Color Corrected" view is shown.
+    ///
+    /// Settings files written before this flag existed were saved when color
+    /// correction was unconditional, so they load as enabled. A fresh
+    /// [`ColorCorrection::default()`] on the other hand starts disabled.
+    #[serde(default = "enabled_when_missing")]
+    pub enabled: bool,
     pub brightness: f32, // -1.0 to 1.0
     pub contrast: f32,   // 0.0 to 2.0
     pub gamma: f32,      // 0.1 to 3.0
@@ -9,6 +17,10 @@ pub struct ColorCorrection {
     pub hue_shift: f32,  // -180.0 to 180.0 degrees
     pub shadows: f32,    // -1.0 to 1.0
     pub highlights: f32, // -1.0 to 1.0
+}
+
+fn enabled_when_missing() -> bool {
+    true
 }
 
 pub enum ColorCorrectionPreset {
@@ -54,6 +66,7 @@ impl ColorCorrectionPreset {
 impl Default for ColorCorrection {
     fn default() -> Self {
         Self {
+            enabled: false,
             brightness: 0.0,
             contrast: 1.0,
             gamma: 1.0,
@@ -66,6 +79,15 @@ impl Default for ColorCorrection {
 }
 
 impl ColorCorrection {
+    /// Replace the correction values with `preset`, leaving [`Self::enabled`]
+    /// alone: picking a preset should not switch the whole section off.
+    pub fn apply_preset(&mut self, preset: ColorCorrection) {
+        *self = ColorCorrection {
+            enabled: self.enabled,
+            ..preset
+        };
+    }
+
     pub fn preset_dark() -> ColorCorrection {
         ColorCorrection {
             contrast: 1.75,

--- a/src/types/color_space.rs
+++ b/src/types/color_space.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub enum ColorSpace {
     Srgb,
     #[default]
@@ -50,7 +50,7 @@ impl ColorSpace {
         }
     }
 
-    pub fn to_id(&self) -> u8 {
+    pub fn to_id(self) -> u8 {
         match self {
             ColorSpace::Srgb => 0,
             ColorSpace::RgbLinear => 1,

--- a/src/types/dither.rs
+++ b/src/types/dither.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub enum DitherMode {
     None,
     #[default]
@@ -44,7 +44,7 @@ impl DitherMode {
         }
     }
 
-    pub fn to_id(&self) -> u8 {
+    pub fn to_id(self) -> u8 {
         match self {
             DitherMode::None => 0,
             DitherMode::Floyd => 0xFE,

--- a/src/types/export.rs
+++ b/src/types/export.rs
@@ -23,15 +23,9 @@ impl ExportFormat {
         }
     }
 
+    /// Formats offered in the export UI. `Png` is reached only through the
+    /// dedicated "Color Corrected PNG" menu entry.
     pub fn indexed_list() -> &'static [ExportFormat] {
         &[ExportFormat::Bmp, ExportFormat::PngIndexed]
     }
-
-    // pub fn all() -> &'static [ExportFormat] {
-    //     &[
-    //         ExportFormat::Bmp,
-    //         ExportFormat::Png,
-    //         ExportFormat::PngIndexed,
-    //     ]
-    // }
 }

--- a/src/types/export.rs
+++ b/src/types/export.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub enum ExportFormat {
     #[default]
     PngIndexed,

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -30,13 +30,13 @@ pub struct TileCountOptions {
     pub allow_flip_y: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PaletteSortSettings {
     pub mode: SortMode,
     pub order: SortOrder,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum SortOrder {
     #[default]
     Ascending,
@@ -55,7 +55,7 @@ impl SortOrder {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum SortMode {
     #[default]
     None,

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -87,101 +87,48 @@ impl SortMode {
 }
 
 impl ImageDataIndexed {
+    /// Reorder the colors inside every palette, rewriting the pixel indices so
+    /// each pixel still resolves to the same color.
     pub fn sorted(
         &self,
         mode: SortMode,
         order: SortOrder,
         first_color_is_transparent: bool,
     ) -> Self {
-        // Get the number of colors per palette from palettes_for_ui
-        if self.palettes_for_ui.is_empty() {
+        let Some(first_palette) = self.palettes_for_ui.first() else {
+            return self.clone();
+        };
+        let colors_per_palette = first_palette.len();
+        if colors_per_palette == 0 {
             return self.clone();
         }
 
-        let colors_per_palette = self.palettes_for_ui[0].len();
-        let num_palettes = self.palettes_for_ui.len();
-
-        // Create a new copy to work with
         let mut new_palettes_for_ui = self.palettes_for_ui.clone();
         let mut new_palettes = self.palettes.clone();
-        let mut new_indexed_pixels = self.indexed_pixels.clone();
 
-        // Process each palette
-        for palette_idx in 0..num_palettes.min(new_palettes_for_ui.len()) {
-            // Get colors for this palette
+        // One global old-index -> new-index table for every palette, so the
+        // pixel buffer is rewritten in a single pass instead of once per
+        // palette. Entries not covered by a complete palette stay identity.
+        let mut remap: [u8; 256] = std::array::from_fn(|i| i as u8);
+
+        for (palette_idx, palette) in self.palettes_for_ui.iter().enumerate() {
             let palette_start = palette_idx * colors_per_palette;
-            let palette_end = palette_start + colors_per_palette;
-
-            if palette_end > self.palettes.len() {
+            if palette.len() != colors_per_palette
+                || palette_start + colors_per_palette > self.palettes.len()
+            {
                 continue;
             }
 
-            // Create index mapping for sorting
-            let mut indices: Vec<usize> = (0..colors_per_palette).collect();
-
-            // Sort indices based on color values
-            indices.sort_by(|&a, &b| {
-                if first_color_is_transparent {
-                    if a == 0 {
-                        return std::cmp::Ordering::Less;
-                    } else if b == 0 {
-                        return std::cmp::Ordering::Greater;
-                    }
-                }
-                let color_a = &self.palettes_for_ui[palette_idx][a];
-                let color_b = &self.palettes_for_ui[palette_idx][b];
-
-                let sort_key_a = Self::get_sort_key(color_a, &mode);
-                let sort_key_b = Self::get_sort_key(color_b, &mode);
-
-                match order {
-                    SortOrder::Ascending => sort_key_a
-                        .partial_cmp(&sort_key_b)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    SortOrder::Descending => sort_key_b
-                        .partial_cmp(&sort_key_a)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                }
+            let mut order_of: Vec<usize> = (0..colors_per_palette).collect();
+            order_of.sort_by(|&a, &b| {
+                Self::compare_colors(palette, a, b, mode, order, first_color_is_transparent)
             });
 
-            // Create reverse mapping (old index -> new index)
-            let mut index_mapping = vec![0; colors_per_palette];
-            for (new_idx, &old_idx) in indices.iter().enumerate() {
-                index_mapping[old_idx] = new_idx;
-            }
-
-            // Update palettes_for_ui for this palette
-            let mut sorted_ui_palette = vec![egui::Color32::BLACK; colors_per_palette];
-            for (new_idx, &old_idx) in indices.iter().enumerate() {
-                sorted_ui_palette[new_idx] = self.palettes_for_ui[palette_idx][old_idx];
-            }
-            new_palettes_for_ui[palette_idx] = sorted_ui_palette;
-
-            // Update palettes for this palette
-            let mut sorted_palette = vec![
-                BGRA8 {
-                    b: 0,
-                    g: 0,
-                    r: 0,
-                    a: 255
-                };
-                colors_per_palette
-            ];
-            for (new_idx, &old_idx) in indices.iter().enumerate() {
-                sorted_palette[new_idx] = self.palettes[palette_start + old_idx];
-            }
-            for (i, color) in sorted_palette.iter().enumerate() {
-                new_palettes[palette_start + i] = *color;
-            }
-
-            // Update indexed_pixels that reference this palette
-            for pixel in new_indexed_pixels.iter_mut() {
-                let pixel_palette_idx = (*pixel as usize) / colors_per_palette;
-                let pixel_color_idx = (*pixel as usize) % colors_per_palette;
-
-                if pixel_palette_idx == palette_idx {
-                    let new_color_idx = index_mapping[pixel_color_idx];
-                    *pixel = (palette_idx * colors_per_palette + new_color_idx) as u8;
+            for (new_idx, &old_idx) in order_of.iter().enumerate() {
+                new_palettes_for_ui[palette_idx][new_idx] = palette[old_idx];
+                new_palettes[palette_start + new_idx] = self.palettes[palette_start + old_idx];
+                if let Some(slot) = remap.get_mut(palette_start + old_idx) {
+                    *slot = (palette_start + new_idx) as u8;
                 }
             }
         }
@@ -189,12 +136,44 @@ impl ImageDataIndexed {
         ImageDataIndexed {
             palettes_for_ui: new_palettes_for_ui,
             palettes: new_palettes,
-            indexed_pixels: new_indexed_pixels,
+            indexed_pixels: self
+                .indexed_pixels
+                .iter()
+                .map(|&pixel| remap[pixel as usize])
+                .collect(),
         }
     }
 
-    fn get_sort_key(color: &egui::Color32, mode: &SortMode) -> f32 {
-        if mode == &SortMode::None {
+    /// Ordering of two entries of the same palette. When the first color is the
+    /// transparent one it is pinned to index 0 regardless of the sort key.
+    fn compare_colors(
+        palette: &[Color32],
+        a: usize,
+        b: usize,
+        mode: SortMode,
+        order: SortOrder,
+        first_color_is_transparent: bool,
+    ) -> std::cmp::Ordering {
+        if first_color_is_transparent {
+            if a == 0 {
+                return std::cmp::Ordering::Less;
+            }
+            if b == 0 {
+                return std::cmp::Ordering::Greater;
+            }
+        }
+
+        let key_a = Self::get_sort_key(&palette[a], mode);
+        let key_b = Self::get_sort_key(&palette[b], mode);
+        let ordering = match order {
+            SortOrder::Ascending => key_a.partial_cmp(&key_b),
+            SortOrder::Descending => key_b.partial_cmp(&key_a),
+        };
+        ordering.unwrap_or(std::cmp::Ordering::Equal)
+    }
+
+    fn get_sort_key(color: &Color32, mode: SortMode) -> f32 {
+        if mode == SortMode::None {
             return 0.0;
         }
         let r = color.r() as f32 / 255.0;

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -195,6 +195,45 @@ impl ImageDataIndexed {
 }
 
 impl ImageData {
+    /// RGBA of the top-left pixel, used as the fill when extending the image.
+    pub fn top_left_pixel(&self) -> [u8; 4] {
+        self.rgba_data
+            .get(0..4)
+            .map_or([0, 0, 0, 0], |px| [px[0], px[1], px[2], px[3]])
+    }
+
+    /// Copy this image into a larger `width` x `height` canvas anchored at the
+    /// top left, filling the added area with `fill`.
+    pub fn extended_to(
+        &self,
+        width: u32,
+        height: u32,
+        fill: [u8; 4],
+        ctx: &egui::Context,
+    ) -> ImageData {
+        let rgba_data = extend_pixels(
+            &self.rgba_data,
+            self.width,
+            self.height,
+            width,
+            height,
+            fill,
+        );
+
+        let size = [width as usize, height as usize];
+        let color_image = ColorImage::from_rgba_unmultiplied(size, &rgba_data);
+        let texture =
+            ctx.load_texture("input_extended", color_image, egui::TextureOptions::NEAREST);
+
+        ImageData {
+            texture,
+            width,
+            height,
+            rgba_data,
+            indexed: None,
+        }
+    }
+
     /// Get the color of the top-left pixel (0, 0)
     pub fn get_top_left_pixel_color(&self) -> Option<Color32> {
         if self.rgba_data.len() >= 4 && self.width > 0 && self.height > 0 {
@@ -420,9 +459,65 @@ impl ImageData {
     }
 }
 
+/// Place `src` at the top left of a `width` x `height` RGBA buffer, filling the
+/// rest with `fill`. Split out from [`ImageData::extended_to`] so it can be
+/// tested without an egui context.
+fn extend_pixels(
+    src: &[u8],
+    src_width: u32,
+    src_height: u32,
+    width: u32,
+    height: u32,
+    fill: [u8; 4],
+) -> Vec<u8> {
+    let copied_width = src_width.min(width);
+    let mut out = Vec::with_capacity((width * height * 4) as usize);
+
+    for y in 0..height {
+        if y < src_height {
+            let row_start = (y * src_width * 4) as usize;
+            let row_end = row_start + (copied_width * 4) as usize;
+            out.extend_from_slice(&src[row_start..row_end]);
+        }
+
+        let already_written = if y < src_height { copied_width } else { 0 };
+        for _ in already_written..width {
+            out.extend_from_slice(&fill);
+        }
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `extended_to` needs a Context for the texture, so the pixel layout is
+    /// covered by a standalone helper that both share.
+    #[test]
+    fn extending_keeps_the_original_at_the_top_left() {
+        // 2x1 image: red, green
+        let src = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let fill = [1, 2, 3, 4];
+        let out = extend_pixels(&src, 2, 1, 4, 3, fill);
+
+        assert_eq!(out.len(), 4 * 3 * 4);
+        assert_eq!(&out[0..4], &[255, 0, 0, 255], "original pixel (0,0)");
+        assert_eq!(&out[4..8], &[0, 255, 0, 255], "original pixel (1,0)");
+        assert_eq!(&out[8..12], &fill, "padding to the right");
+        assert_eq!(&out[12..16], &fill, "padding to the right");
+        assert!(
+            out[16..].chunks_exact(4).all(|px| px == fill),
+            "every added row is filled"
+        );
+    }
+
+    #[test]
+    fn extending_to_the_same_size_is_a_copy() {
+        let src = vec![9, 8, 7, 6, 5, 4, 3, 2];
+        assert_eq!(extend_pixels(&src, 2, 1, 2, 1, [0; 4]), src);
+    }
 
     fn bgra(r: u8, g: u8, b: u8, a: u8) -> BGRA8 {
         BGRA8 { b, g, r, a }

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -286,7 +286,7 @@ impl ImageData {
         let color_image = ColorImage::from_rgba_unmultiplied(size, &pixels);
         let texture = ctx.load_texture("output", color_image, egui::TextureOptions::NEAREST);
 
-        // パレット情報を直接変換
+        // Split the flat palette into per-palette rows for the overlay.
         let palettes_for_ui = Self::convert_palette_data(
             &palette_data,
             settings.n_palettes as usize,

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -440,3 +440,194 @@ impl ImageData {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bgra(r: u8, g: u8, b: u8, a: u8) -> BGRA8 {
+        BGRA8 { b, g, r, a }
+    }
+
+    fn ui_color(c: &BGRA8) -> Color32 {
+        Color32::from_rgba_unmultiplied(c.r, c.g, c.b, c.a)
+    }
+
+    fn indexed(
+        palettes: Vec<BGRA8>,
+        colors_per_palette: usize,
+        pixels: Vec<u8>,
+    ) -> ImageDataIndexed {
+        let palettes_for_ui = palettes
+            .chunks(colors_per_palette)
+            .map(|chunk| chunk.iter().map(ui_color).collect())
+            .collect();
+        ImageDataIndexed {
+            palettes_for_ui,
+            palettes,
+            indexed_pixels: pixels,
+        }
+    }
+
+    fn opts(visible_only: bool, flip_x: bool, flip_y: bool) -> TileCountOptions {
+        TileCountOptions {
+            visible_only,
+            allow_flip_x: flip_x,
+            allow_flip_y: flip_y,
+        }
+    }
+
+    /// 4x2 image, 2x2 tiles: the right tile is the horizontal mirror of the left one.
+    fn mirrored_pair() -> ImageDataIndexed {
+        let palettes = (0..5).map(|i| bgra(i * 10, i * 10, i * 10, 255)).collect();
+        #[rustfmt::skip]
+        let pixels = vec![
+            1, 2,   2, 1,
+            3, 4,   4, 3,
+        ];
+        indexed(palettes, 5, pixels)
+    }
+
+    #[test]
+    fn count_unique_tiles_collapses_mirrored_tiles() {
+        let image = mirrored_pair();
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 2, 2, opts(false, true, false)),
+            Some(1)
+        );
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 2, 2, opts(false, false, false)),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn count_unique_tiles_can_skip_fully_transparent_tiles() {
+        let mut palettes: Vec<BGRA8> = (0..5).map(|i| bgra(i * 10, i * 10, i * 10, 255)).collect();
+        palettes[0] = bgra(0, 0, 0, 0);
+        #[rustfmt::skip]
+        let pixels = vec![
+            1, 2,   0, 0,
+            3, 4,   0, 0,
+        ];
+        let image = indexed(palettes, 5, pixels);
+
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 2, 2, opts(true, false, false)),
+            Some(1)
+        );
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 2, 2, opts(false, false, false)),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn count_unique_tiles_rejects_indivisible_dimensions() {
+        let image = mirrored_pair();
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 3, 2, opts(false, false, false)),
+            None
+        );
+        assert_eq!(
+            ImageData::count_unique_tiles(&image, 4, 2, 0, 2, opts(false, false, false)),
+            None
+        );
+    }
+
+    /// Two palettes of four colors, deliberately unsorted by luminance.
+    fn two_palettes() -> ImageDataIndexed {
+        let palettes = vec![
+            bgra(200, 200, 200, 255),
+            bgra(0, 0, 0, 255),
+            bgra(120, 120, 120, 255),
+            bgra(60, 60, 60, 255),
+            bgra(10, 10, 10, 255),
+            bgra(250, 250, 250, 255),
+            bgra(40, 40, 40, 255),
+            bgra(180, 180, 180, 255),
+        ];
+        indexed(palettes, 4, vec![0, 1, 2, 3, 4, 5, 6, 7])
+    }
+
+    /// The color each pixel resolves to must be unchanged by sorting; only the
+    /// indices and the palette layout move.
+    fn resolved_colors(image: &ImageDataIndexed, colors_per_palette: usize) -> Vec<Color32> {
+        image
+            .indexed_pixels
+            .iter()
+            .map(|&px| {
+                let palette = px as usize / colors_per_palette;
+                let color = px as usize % colors_per_palette;
+                image.palettes_for_ui[palette][color]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn sorted_preserves_resolved_pixel_colors() {
+        let image = two_palettes();
+        let before = resolved_colors(&image, 4);
+
+        let sorted = image.sorted(SortMode::Luminance, SortOrder::Ascending, false);
+
+        assert_eq!(resolved_colors(&sorted, 4), before);
+        assert_eq!(sorted.palettes.len(), image.palettes.len());
+    }
+
+    #[test]
+    fn sorted_orders_each_palette_independently() {
+        let sorted = two_palettes().sorted(SortMode::Luminance, SortOrder::Ascending, false);
+
+        for palette in &sorted.palettes_for_ui {
+            let luminances: Vec<u8> = palette.iter().map(|c| c.r()).collect();
+            assert!(
+                luminances.windows(2).all(|w| w[0] <= w[1]),
+                "palette not ascending: {luminances:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sorted_descending_reverses_the_order() {
+        let sorted = two_palettes().sorted(SortMode::Luminance, SortOrder::Descending, false);
+
+        for palette in &sorted.palettes_for_ui {
+            let luminances: Vec<u8> = palette.iter().map(|c| c.r()).collect();
+            assert!(
+                luminances.windows(2).all(|w| w[0] >= w[1]),
+                "palette not descending: {luminances:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sorted_pins_the_transparent_first_color() {
+        let sorted = two_palettes().sorted(SortMode::Luminance, SortOrder::Ascending, true);
+
+        // Index 0 of each palette must keep its original color.
+        assert_eq!(
+            sorted.palettes_for_ui[0][0],
+            ui_color(&bgra(200, 200, 200, 255))
+        );
+        assert_eq!(
+            sorted.palettes_for_ui[1][0],
+            ui_color(&bgra(10, 10, 10, 255))
+        );
+        assert_eq!(
+            resolved_colors(&sorted, 4),
+            resolved_colors(&two_palettes(), 4)
+        );
+    }
+
+    #[test]
+    fn sorted_is_a_noop_without_palettes() {
+        let empty = ImageDataIndexed {
+            palettes_for_ui: Vec::new(),
+            palettes: Vec::new(),
+            indexed_pixels: vec![0, 1, 2],
+        };
+        let sorted = empty.sorted(SortMode::Luminance, SortOrder::Ascending, false);
+        assert_eq!(sorted.indexed_pixels, vec![0, 1, 2]);
+    }
+}

--- a/src/types/preferences.rs
+++ b/src/types/preferences.rs
@@ -33,10 +33,6 @@ mod color32_def {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserPreferences {
     pub show_advanced: bool,
-    pub show_original_image: bool,
-
-    #[serde(default)]
-    pub show_color_corrected_image: bool,
     pub show_palettes: bool,
 
     #[serde(default)]
@@ -56,8 +52,6 @@ impl Default for UserPreferences {
     fn default() -> Self {
         Self {
             show_advanced: false,
-            show_original_image: true,
-            show_color_corrected_image: false,
             show_palettes: true,
             show_debug_info: false,
             show_appearance: false,

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -83,7 +83,7 @@ impl ClearColor {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QualetizeSettings {
     pub tile_width: u16,
     pub tile_height: u16,

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -62,7 +62,7 @@ pub struct BGRA8 {
     pub a: u8,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ClearColor {
     #[default]
     None,
@@ -70,7 +70,7 @@ pub enum ClearColor {
 }
 
 impl ClearColor {
-    pub fn to_bgra8(&self) -> BGRA8 {
+    pub fn to_bgra8(self) -> BGRA8 {
         match self {
             ClearColor::None => BGRA8 {
                 b: 0,
@@ -78,12 +78,7 @@ impl ClearColor {
                 r: 0,
                 a: 0,
             },
-            ClearColor::Rgb(r, g, b) => BGRA8 {
-                b: *b,
-                g: *g,
-                r: *r,
-                a: 0xFF,
-            },
+            ClearColor::Rgb(r, g, b) => BGRA8 { b, g, r, a: 0xFF },
         }
     }
 }

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -389,3 +389,86 @@ impl From<QualetizeSettings> for QualetizePlanOwned {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_0_255_array_accepts_well_formed_lists() {
+        assert!(validate_0_255_array("0"));
+        assert!(validate_0_255_array("0,255"));
+        assert!(validate_0_255_array("0,49,87,119,146,174,206,255"));
+    }
+
+    #[test]
+    fn validate_0_255_array_rejects_malformed_lists() {
+        assert!(!validate_0_255_array(""), "empty");
+        assert!(!validate_0_255_array("256"), "out of range");
+        assert!(!validate_0_255_array("0, 255"), "whitespace");
+        assert!(!validate_0_255_array("0,"), "trailing comma");
+        assert!(!validate_0_255_array("00"), "leading zero");
+        assert!(!validate_0_255_array("0;255"), "wrong separator");
+    }
+
+    #[test]
+    fn validate_0_255_array_rejects_more_entries_than_the_plan_can_hold() {
+        let at_limit = vec!["1"; MAX_CUSTOM_LEVELS].join(",");
+        let over_limit = vec!["1"; MAX_CUSTOM_LEVELS + 1].join(",");
+        assert!(validate_0_255_array(&at_limit));
+        assert!(!validate_0_255_array(&over_limit));
+    }
+
+    #[test]
+    fn parse_custom_levels_normalizes_and_sorts() {
+        let levels = parse_custom_levels("255,0,128").expect("valid list");
+        assert_eq!(levels.len(), 3);
+        assert!(levels[0] < levels[1] && levels[1] < levels[2]);
+        assert_eq!(levels[0], 0.0);
+        assert_eq!(levels[2], 1.0);
+    }
+
+    #[test]
+    fn parse_custom_levels_rejects_invalid_input() {
+        assert!(parse_custom_levels("0,256").is_none());
+        assert!(parse_custom_levels("").is_none());
+    }
+
+    /// A full 8-bit channel needs 256 steps but the plan stores the count in a `u8`,
+    /// so `depth_to_levels` clamps to 254 steps (255 entries) and stays valid.
+    #[test]
+    fn generated_levels_always_fit_the_plan() {
+        for depth in ["3331", "5551", "8888"] {
+            for (channel, levels) in default_level_strings_from_depth(depth).iter().enumerate() {
+                let count = levels.split(',').count();
+                assert!(
+                    count <= MAX_CUSTOM_LEVELS,
+                    "{depth} channel {channel} produced {count} levels"
+                );
+                assert!(
+                    validate_0_255_array(levels),
+                    "{depth} channel {channel} is not accepted by its own validator"
+                );
+                assert!(u8::try_from(count).is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn genesis_preset_uses_the_documented_levels() {
+        let settings = QualetizeSettings::genesis();
+        assert!(settings.use_custom_levels);
+        assert_eq!(settings.custom_levels[0], "0,49,87,119,146,174,206,255");
+        assert_eq!(settings.custom_levels[3], "0,255");
+    }
+
+    #[test]
+    fn full_palette_presets_only_change_palette_layout() {
+        let base = QualetizeSettings::genesis();
+        let full = QualetizeSettings::genesis_full_palettes();
+        assert_eq!(full.n_palettes, 4);
+        assert!(full.col0_is_clear);
+        assert_eq!(full.rgba_depth, base.rgba_depth);
+        assert_eq!(full.custom_levels, base.custom_levels);
+    }
+}

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -3,6 +3,11 @@ use super::dither::DitherMode;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::ptr;
+use std::sync::LazyLock;
+
+/// The C plan stores the per-channel level count in a `u8`, so a channel can hold
+/// at most 255 entries.
+pub const MAX_CUSTOM_LEVELS: usize = u8::MAX as usize;
 
 #[cfg(target_arch = "x86_64")]
 #[repr(C, align(16))]
@@ -298,23 +303,22 @@ fn default_custom_level_strings() -> [String; 4] {
     default_level_strings_from_depth(DEFAULT_RGBA_DEPTH)
 }
 
+/// Comma separated list of 0-255 integers, without leading zeros or whitespace.
+static LEVEL_LIST_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])(,(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]|[1-9][0-9]))*$")
+        .expect("level list regex is valid")
+});
+
 pub fn validate_0_255_array(array_str: &str) -> bool {
     if array_str.is_empty() {
         return false;
     }
 
-    let re = Regex::new(r"^(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])(,(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]|[1-9][0-9]))*$").unwrap();
-
-    if !re.is_match(array_str) {
+    if !LEVEL_LIST_RE.is_match(array_str) {
         return false;
     }
 
-    let count = array_str.split(',').count();
-    if count > 255 {
-        return false;
-    }
-
-    true
+    array_str.split(',').count() <= MAX_CUSTOM_LEVELS
 }
 
 fn parse_custom_levels(array_str: &str) -> Option<Vec<f32>> {

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -151,6 +151,31 @@ impl QualetizePreset {
 }
 
 impl QualetizeSettings {
+    /// Replace the quantization settings with `preset`, leaving the tile
+    /// reduction post-pass alone.
+    ///
+    /// Tile reduction only lives in this struct because it is serialized
+    /// alongside; it is a separate stage with its own reset, so a quantization
+    /// preset should no more disturb it than it does color correction.
+    pub fn apply_preset(&mut self, preset: QualetizeSettings) {
+        *self = QualetizeSettings {
+            tile_reduce_post_enabled: self.tile_reduce_post_enabled,
+            tile_reduce_post_threshold: self.tile_reduce_post_threshold,
+            tile_reduce_allow_flip_x: self.tile_reduce_allow_flip_x,
+            tile_reduce_allow_flip_y: self.tile_reduce_allow_flip_y,
+            ..preset
+        };
+    }
+
+    /// Restore the tile reduction post-pass to its defaults, leaving the
+    /// quantization settings alone. The enable flag is kept, the same way a
+    /// color correction preset does not switch that section off.
+    pub fn reset_tile_reduce(&mut self) {
+        self.tile_reduce_post_threshold = default_tile_reduce_post_threshold();
+        self.tile_reduce_allow_flip_x = default_tile_reduce_allow_flip();
+        self.tile_reduce_allow_flip_y = default_tile_reduce_allow_flip();
+    }
+
     pub fn gba_nds() -> Self {
         let rgba_depth = "5551".to_string();
         Self {
@@ -447,6 +472,49 @@ mod tests {
                 assert!(u8::try_from(count).is_ok());
             }
         }
+    }
+
+    /// The regression this pair of helpers exists for: switching quantization
+    /// preset used to silently reset the tile reduction post-pass with it.
+    #[test]
+    fn applying_a_preset_leaves_tile_reduction_alone() {
+        let mut settings = QualetizeSettings::genesis();
+        settings.tile_reduce_post_enabled = true;
+        settings.tile_reduce_post_threshold = 123.0;
+        settings.tile_reduce_allow_flip_x = false;
+        settings.tile_reduce_allow_flip_y = false;
+
+        settings.apply_preset(QualetizeSettings::gba_nds());
+
+        assert_eq!(settings.color_space, ColorSpace::YcbcrPsy, "preset applied");
+        assert_eq!(settings.rgba_depth, "5551", "preset applied");
+        assert!(settings.tile_reduce_post_enabled, "tile reduction kept");
+        assert_eq!(settings.tile_reduce_post_threshold, 123.0);
+        assert!(!settings.tile_reduce_allow_flip_x);
+        assert!(!settings.tile_reduce_allow_flip_y);
+    }
+
+    #[test]
+    fn resetting_tile_reduction_leaves_quantization_alone() {
+        let mut settings = QualetizeSettings::gba_nds();
+        settings.n_palettes = 7;
+        settings.tile_reduce_post_enabled = true;
+        settings.tile_reduce_post_threshold = 123.0;
+        settings.tile_reduce_allow_flip_x = false;
+
+        settings.reset_tile_reduce();
+
+        assert_eq!(settings.n_palettes, 7, "quantization untouched");
+        assert_eq!(settings.color_space, ColorSpace::YcbcrPsy);
+        assert_eq!(
+            settings.tile_reduce_post_threshold,
+            default_tile_reduce_post_threshold()
+        );
+        assert!(settings.tile_reduce_allow_flip_x);
+        assert!(
+            settings.tile_reduce_post_enabled,
+            "reset restores values, not the enable flag"
+        );
     }
 
     #[test]

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -2,8 +2,7 @@ use super::styles;
 use crate::types::{AppState, ExportFormat, app_state::AppStateRequest, image::ImageData};
 use egui::{Color32, Vec2};
 
-pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) -> bool {
-    let export_clicked = false;
+pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) {
     let width = ui.available_width();
 
     ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
@@ -17,8 +16,6 @@ pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         ui.separator();
         draw_export_controls(ui, state);
     });
-
-    export_clicked
 }
 
 fn draw_view_controls(ui: &mut egui::Ui, state: &mut AppState) {
@@ -143,8 +140,6 @@ fn compute_tile_count(state: &mut AppState) -> Option<usize> {
 fn apply_export_button_style(ui: &mut egui::Ui) {
     ui.style_mut().spacing.button_padding = egui::vec2(10.0, 4.0);
     let style = &mut ui.style_mut();
-
-    // style.spacing.button_padding = egui::vec2(10.0, 4.0);
 
     // Inactive state
     style.visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0, Color32::WHITE);

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -48,7 +48,7 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
                 _ = state
                     .app_state_request_sender
                     .send(AppStateRequest::ExportImageDialog {
-                        format: state.preferences.selected_export_format.clone(),
+                        format: state.preferences.selected_export_format,
                         suffix: Some("qualetized".to_string()),
                     });
             }
@@ -62,7 +62,7 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
                 for format in ExportFormat::indexed_list() {
                     ui.selectable_value(
                         &mut state.preferences.selected_export_format,
-                        format.clone(),
+                        *format,
                         format.display_name(),
                     );
                 }
@@ -142,16 +142,16 @@ fn apply_export_button_style(ui: &mut egui::Ui) {
     let style = &mut ui.style_mut();
 
     // Inactive state
-    style.visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0, Color32::WHITE);
+    style.visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0_f32, Color32::WHITE);
     style.visuals.widgets.inactive.weak_bg_fill = styles::COLOR_TINT;
 
     // Hovered state
-    style.visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0, styles::COLOR_TINT_ACTIVE);
-    style.visuals.widgets.hovered.fg_stroke = egui::Stroke::new(1.0, Color32::WHITE);
+    style.visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0_f32, styles::COLOR_TINT_ACTIVE);
+    style.visuals.widgets.hovered.fg_stroke = egui::Stroke::new(1.0_f32, Color32::WHITE);
     style.visuals.widgets.hovered.weak_bg_fill = styles::COLOR_TINT;
 
     // Active state
-    style.visuals.widgets.active.bg_stroke = egui::Stroke::new(1.0, styles::COLOR_TINT_ACTIVE);
-    style.visuals.widgets.active.fg_stroke = egui::Stroke::new(1.0, Color32::WHITE);
+    style.visuals.widgets.active.bg_stroke = egui::Stroke::new(1.0_f32, styles::COLOR_TINT_ACTIVE);
+    style.visuals.widgets.active.fg_stroke = egui::Stroke::new(1.0_f32, Color32::WHITE);
     style.visuals.widgets.active.weak_bg_fill = styles::COLOR_TINT;
 }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,5 +1,9 @@
 use super::styles;
-use crate::types::{AppState, ExportFormat, app_state::AppStateRequest, image::ImageData};
+use crate::types::{
+    AppState, ExportFormat,
+    app_state::{AppStateRequest, ExportSource},
+    image::ImageData,
+};
 use egui::{Color32, Vec2};
 
 pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) {
@@ -45,11 +49,18 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
                 egui::Button::new("💾 Export Image"),
             );
             if response.clicked() {
+                // The button exports whatever the last enabled pass produced,
+                // i.e. the image shown in the bottom right view.
+                let source = if state.settings.tile_reduce_post_enabled {
+                    ExportSource::TileReduced
+                } else {
+                    ExportSource::Qualetized
+                };
                 _ = state
                     .app_state_request_sender
                     .send(AppStateRequest::ExportImageDialog {
+                        source,
                         format: state.preferences.selected_export_format,
-                        suffix: Some("qualetized".to_string()),
                     });
             }
         });

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -97,7 +97,7 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
                     if ui
                         .selectable_value(
                             &mut state.preferences.selected_export_format,
-                            format.clone(),
+                            *format,
                             format.display_name(),
                         )
                         .clicked()

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,4 +1,4 @@
-use crate::types::app_state::AppStateRequest;
+use crate::types::app_state::{AppStateRequest, ExportSource};
 use crate::types::{
     AppState, ExportFormat, QualetizePreset, app_state::AppearanceMode,
     color_correction::ColorCorrectionPreset,
@@ -20,37 +20,45 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             ui.separator();
 
             ui.menu_button("Export Image", |ui| {
-                ui.add_enabled_ui(state.color_corrected_image.is_some(), |ui| {
-                    if ui.button("Color Corrected PNG").clicked() {
-                        _ = state.app_state_request_sender.send(
-                            AppStateRequest::ExportImageDialog {
-                                format: ExportFormat::Png,
-                                suffix: Some("color_corrected".to_string()),
-                            },
-                        );
+                // Passes that are switched off have nothing to export, so their
+                // entries stay visible but disabled.
+                const ENTRIES: [(ExportSource, ExportFormat, &str); 5] = [
+                    (
+                        ExportSource::ColorCorrected,
+                        ExportFormat::Png,
+                        "Color Corrected PNG",
+                    ),
+                    (
+                        ExportSource::Qualetized,
+                        ExportFormat::PngIndexed,
+                        "Qualetized PNG",
+                    ),
+                    (
+                        ExportSource::Qualetized,
+                        ExportFormat::Bmp,
+                        "Qualetized BMP",
+                    ),
+                    (
+                        ExportSource::TileReduced,
+                        ExportFormat::PngIndexed,
+                        "Tile Reduced PNG",
+                    ),
+                    (
+                        ExportSource::TileReduced,
+                        ExportFormat::Bmp,
+                        "Tile Reduced BMP",
+                    ),
+                ];
+
+                for (source, format, label) in ENTRIES {
+                    let enabled = state.can_export(source);
+                    if ui.add_enabled(enabled, egui::Button::new(label)).clicked() {
+                        _ = state
+                            .app_state_request_sender
+                            .send(AppStateRequest::ExportImageDialog { source, format });
                         ui.close();
                     }
-                });
-                ui.add_enabled_ui(state.output_image.is_some(), |ui| {
-                    if ui.button("Qualetized Indexed PNG").clicked() {
-                        _ = state.app_state_request_sender.send(
-                            AppStateRequest::ExportImageDialog {
-                                format: ExportFormat::PngIndexed,
-                                suffix: Some("qualetized".to_string()),
-                            },
-                        );
-                        ui.close();
-                    }
-                    if ui.button("Qualetized Indexed BMP").clicked() {
-                        _ = state.app_state_request_sender.send(
-                            AppStateRequest::ExportImageDialog {
-                                format: ExportFormat::Bmp,
-                                suffix: Some("qualetized".to_string()),
-                            },
-                        );
-                        ui.close();
-                    }
-                });
+                }
             });
 
             ui.separator();

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -5,8 +5,11 @@ use crate::types::{
 };
 use crate::ui::styles::UiMarginExt;
 
-pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
+/// Returns `(settings_changed, tile_reduce_changed)`, matching the settings
+/// panel: resetting tile reduction only needs the post-pass to rerun.
+pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
     let mut settings_changed = false;
+    let mut tile_reduce_changed = false;
 
     egui::MenuBar::new().ui(ui, |ui| {
         // --- File menu ---
@@ -84,12 +87,17 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             ui.menu_button("Reset Qualetize", |ui| {
                 for preset in QualetizePreset::all() {
                     if ui.button(preset.display_name()).clicked() {
-                        state.settings = preset.qualetize_settings();
+                        state.settings.apply_preset(preset.qualetize_settings());
                         settings_changed = true;
                         ui.close();
                     }
                 }
             });
+            if ui.button("Reset Tile Reduction").clicked() {
+                state.settings.reset_tile_reduce();
+                tile_reduce_changed = true;
+                ui.close();
+            }
             ui.menu_button("Reset Color Correction", |ui| {
                 for preset in ColorCorrectionPreset::all() {
                     if ui.button(preset.display_name()).clicked() {
@@ -248,5 +256,5 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         state.preferences.show_appearance = show_dialog;
     }
 
-    settings_changed
+    (settings_changed, tile_reduce_changed)
 }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -85,7 +85,9 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             ui.menu_button("Reset Color Correction", |ui| {
                 for preset in ColorCorrectionPreset::all() {
                     if ui.button(preset.display_name()).clicked() {
-                        state.color_correction = preset.color_correction();
+                        state
+                            .color_correction
+                            .apply_preset(preset.color_correction());
                         settings_changed = true;
                         ui.close();
                     }
@@ -121,14 +123,6 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
 
                 ui.separator();
                 ui.label(egui::widget_text::RichText::new("Canvas").small());
-                ui.checkbox(&mut state.preferences.show_original_image, "Original Image");
-                ui.checkbox(
-                    &mut state.preferences.show_color_corrected_image,
-                    "Color Corrected Image",
-                );
-
-                ui.separator();
-
                 ui.checkbox(&mut state.preferences.show_palettes, "Palettes");
 
                 ui.separator();

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -146,7 +146,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
     }
 
     if ui.ui_contains_pointer() {
-        let scroll_delta = ui.ctx().input(|i| i.raw_scroll_delta.y);
+        let scroll_delta = ui.ctx().input(|i| i.smooth_scroll_delta.y);
         if scroll_delta != 0.0 {
             let zoom_factor = 1.0 + scroll_delta * 0.001;
             state.zoom = (state.zoom * zoom_factor).clamp(0.1, 20.0);
@@ -242,14 +242,15 @@ fn draw_title(painter: &egui::Painter, canvas: Rect, title: &str, ui_ctx: &egui:
         return;
     }
 
-    let visuals = &ui_ctx.style().visuals;
+    let style = ui_ctx.global_style();
+    let visuals = &style.visuals;
     let window_color = visuals.window_fill();
     let bg_color =
         Color32::from_rgba_unmultiplied(window_color.r(), window_color.g(), window_color.b(), 178);
     let text_color = visuals.override_text_color.unwrap_or(visuals.text_color());
 
     let galley =
-        ui_ctx.fonts(|f| f.layout_no_wrap(title.to_string(), FontId::default(), text_color));
+        ui_ctx.fonts_mut(|f| f.layout_no_wrap(title.to_string(), FontId::default(), text_color));
 
     let pos = canvas.left_bottom() + Vec2::new(4.0, -20.0);
     let rect = Align2::LEFT_TOP.align_size_within_rect(
@@ -278,14 +279,15 @@ fn draw_spinner(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Context) {
 }
 
 fn draw_overlay_text(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Context, text: &str) {
-    let visuals = &ui_ctx.style().visuals;
+    let style = ui_ctx.global_style();
+    let visuals = &style.visuals;
     let panel = visuals.panel_fill;
     // Use theme-aware background with slight translucency
     let bg_color = Color32::from_rgba_unmultiplied(panel.r(), panel.g(), panel.b(), 200);
     let text_color = visuals.strong_text_color();
     let font_id = egui::FontId::proportional(15.0); // slightly larger to emphasize toast text
 
-    let galley = ui_ctx.fonts(|f| f.layout_no_wrap(text.to_string(), font_id, text_color));
+    let galley = ui_ctx.fonts_mut(|f| f.layout_no_wrap(text.to_string(), font_id, text_color));
     let rect = Align2::CENTER_CENTER.align_size_within_rect(
         galley.size() + egui::vec2(12.0, 6.0),
         Rect::from_center_size(canvas.center(), galley.size() + egui::vec2(12.0, 6.0)),
@@ -509,7 +511,7 @@ fn draw_single_palette(
     hovered: Option<(usize, usize)>,
 ) {
     let palette_width = (palette.len() as f32) * (palette_size + palette_spacing) - palette_spacing;
-    let highlight_color = painter.ctx().style().visuals.selection.stroke.color;
+    let highlight_color = painter.ctx().global_style().visuals.selection.stroke.color;
 
     for (color_idx, &color) in palette.iter().enumerate() {
         let x = origin.x - palette_width + (color_idx as f32) * (palette_size + palette_spacing);

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -244,9 +244,6 @@ fn draw_main_image(
     }
 }
 
-/// Warning color, matching the one used by the settings panel.
-const NOTICE_COLOR: Color32 = Color32::from_rgb(255, 180, 0);
-
 /// A small text chip drawn over the image, used for titles and notices.
 fn draw_label_chip(
     painter: &egui::Painter,
@@ -285,7 +282,8 @@ fn draw_title(painter: &egui::Painter, canvas: Rect, title: &str, ui_ctx: &egui:
 /// seeing rather than a toast that fades.
 fn draw_notice(painter: &egui::Painter, canvas: Rect, text: &str, ui_ctx: &egui::Context) {
     let pos = canvas.left_top() + Vec2::new(4.0, 4.0);
-    draw_label_chip(painter, ui_ctx, pos, text, NOTICE_COLOR);
+    let color = super::styles::warning_color(&ui_ctx.global_style().visuals);
+    draw_label_chip(painter, ui_ctx, pos, text, color);
 }
 
 fn draw_spinner(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Context) {

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -1,127 +1,163 @@
 use super::styles::UiMarginExt;
-use crate::types::AppState;
+use crate::types::{AppState, ImageData};
 use egui::{Align2, Color32, FontId, Id, Pos2, Rect, Vec2};
 
-pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, image_processing: bool) {
-    const HORIZONTAL_MARGIN: f32 = 4.0;
+/// Gap between the image panels.
+const PANEL_MARGIN: f32 = 4.0;
+
+/// Everything one image panel needs to draw itself.
+struct ImagePanel<'a> {
+    title: &'a str,
+    image: &'a Option<ImageData>,
+    size: Vec2,
+    zoom: f32,
+    pan_offset: Vec2,
+    background: Color32,
+    has_spinner: bool,
+    overlay_text: Option<&'a str>,
+    palettes: Option<&'a Vec<Vec<Color32>>>,
+}
+
+pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_processing: bool) {
     let available_size = ui.available_size();
+    let toast = live_toast(state, ui.ctx());
 
     let zoom = state.zoom;
     let pan_offset = state.pan_offset;
-    let mut pan_changed = egui::Vec2::ZERO;
+    let background = state
+        .preferences
+        .background_color
+        .unwrap_or(Color32::from_gray(64));
+    let mut pan_changed = Vec2::ZERO;
 
-    let split_x =
-        if state.preferences.show_original_image || state.preferences.show_color_corrected_image {
-            (available_size.x - HORIZONTAL_MARGIN) / 2.0
-        } else {
-            available_size.x
-        };
-    let split_y =
-        if state.preferences.show_original_image && state.preferences.show_color_corrected_image {
-            (available_size.y - HORIZONTAL_MARGIN) / 2.0
-        } else {
-            available_size.y
-        };
+    // Left column holds the inputs, right column the outputs. The optional
+    // panels appear exactly when their pass is enabled.
+    let show_color_corrected = state.color_correction.enabled;
+    let show_tile_reduced = state.settings.tile_reduce_post_enabled;
+
+    // The palette is identical for both output panels, so it is only drawn on
+    // the Qualetized one to keep its position stable.
+    let palettes = state
+        .preferences
+        .show_palettes
+        .then(|| {
+            state
+                .output_palette_sorted_indexed_image
+                .as_ref()
+                .or_else(|| state.output_image.as_ref().and_then(|i| i.indexed.as_ref()))
+                .map(|indexed| &indexed.palettes_for_ui)
+        })
+        .flatten();
+
+    let column_width = (available_size.x - PANEL_MARGIN) / 2.0;
+    let input_height = column_height(available_size.y, 1 + usize::from(show_color_corrected));
+    let output_height = column_height(available_size.y, 1 + usize::from(show_tile_reduced));
 
     ui.horizontal(|ui| {
-        ui.style_mut().spacing.item_spacing = egui::vec2(HORIZONTAL_MARGIN, 0.0);
-        // Left panel - Original image
+        ui.style_mut().spacing.item_spacing = egui::vec2(PANEL_MARGIN, 0.0);
+
+        // Inputs
         ui.vertical(|ui| {
-            ui.style_mut().spacing.item_spacing = egui::vec2(0.0, HORIZONTAL_MARGIN);
-            if state.preferences.show_original_image {
-                let settings = ImagePanelSettings {
-                    width: split_x,
-                    height: split_y,
+            ui.style_mut().spacing.item_spacing = egui::vec2(0.0, PANEL_MARGIN);
+
+            draw_image_panel(
+                ui,
+                ImagePanel {
+                    title: "Original",
+                    image: &state.input_image,
+                    size: Vec2::new(column_width, input_height),
                     zoom,
                     pan_offset,
-                    title: "Original".into(),
+                    background,
                     has_spinner: false,
                     overlay_text: None,
-                };
+                    palettes: None,
+                },
+                &mut pan_changed,
+            );
+
+            if show_color_corrected {
                 draw_image_panel(
                     ui,
-                    state,
-                    settings,
-                    &state.input_image,
-                    None,
-                    &mut pan_changed,
-                );
-            }
-            if state.preferences.show_color_corrected_image {
-                let settings = ImagePanelSettings {
-                    width: split_x,
-                    height: split_y,
-                    zoom,
-                    pan_offset,
-                    title: "Color Corrected".into(),
-                    has_spinner: state.color_corrected_image.is_none(),
-                    overlay_text: None,
-                };
-                draw_image_panel(
-                    ui,
-                    state,
-                    settings,
-                    &state.color_corrected_image,
-                    None,
+                    ImagePanel {
+                        title: "Color Corrected",
+                        image: &state.color_corrected_image,
+                        size: Vec2::new(column_width, input_height),
+                        zoom,
+                        pan_offset,
+                        background,
+                        has_spinner: state.color_corrected_image.is_none(),
+                        overlay_text: None,
+                        palettes: None,
+                    },
                     &mut pan_changed,
                 );
             }
         });
 
-        // Right panel
-        if !state.tile_size_warning {
-            let toast = live_toast(state, ui.ctx());
+        // Outputs, or the warning that replaces them
+        if state.tile_size_warning {
+            draw_status_panel(ui, state, column_width, available_size.y);
+            return;
+        }
 
-            // Prefer the sorted palette when one is active.
-            let palettes_for_ui = state
-                .output_palette_sorted_indexed_image
-                .as_ref()
-                .or_else(|| state.output_image.as_ref().and_then(|i| i.indexed.as_ref()))
-                .map(|indexed| &indexed.palettes_for_ui);
-            let tile_reduced = state.settings.tile_reduce_post_enabled
-                && (state.tile_reduce_processing || state.reduced_tile_count.is_some());
+        ui.vertical(|ui| {
+            ui.style_mut().spacing.item_spacing = egui::vec2(0.0, PANEL_MARGIN);
 
-            let settings = ImagePanelSettings {
-                width: split_x,
-                height: available_size.y,
-                zoom,
-                pan_offset,
-                title: if tile_reduced {
-                    "Qualetized + Tile Reduced".into()
-                } else {
-                    "Qualetized".into()
-                },
-                has_spinner: image_processing,
-                overlay_text: toast,
-            };
             draw_image_panel(
                 ui,
-                state,
-                settings,
-                &state.output_image,
-                palettes_for_ui,
+                ImagePanel {
+                    title: "Qualetized",
+                    image: &state.base_output_image,
+                    size: Vec2::new(column_width, output_height),
+                    zoom,
+                    pan_offset,
+                    background,
+                    has_spinner: qualetize_processing,
+                    overlay_text: None,
+                    palettes,
+                },
                 &mut pan_changed,
             );
-        } else {
-            // Status/ Warning message
-            draw_status_panel(ui, state, split_x, available_size.y);
-        }
+
+            if show_tile_reduced {
+                draw_image_panel(
+                    ui,
+                    ImagePanel {
+                        title: "Tile Reduced",
+                        image: &state.output_image,
+                        size: Vec2::new(column_width, output_height),
+                        zoom,
+                        pan_offset,
+                        background,
+                        // A new quantization invalidates the reduced result too.
+                        has_spinner: qualetize_processing || state.tile_reduce_processing,
+                        overlay_text: toast.as_deref(),
+                        palettes: None,
+                    },
+                    &mut pan_changed,
+                );
+            }
+        });
     });
 
-    // Apply changes back to state (this block is common to both views)
-    if pan_changed != egui::Vec2::ZERO {
+    if pan_changed != Vec2::ZERO {
         state.pan_offset += pan_changed;
     }
 
-    // Handle mouse interaction (this block is also common)
     if ui.ui_contains_pointer() {
-        let ctx = ui.ctx();
-        let scroll_delta = ctx.input(|i| i.raw_scroll_delta.y);
+        let scroll_delta = ui.ctx().input(|i| i.raw_scroll_delta.y);
         if scroll_delta != 0.0 {
             let zoom_factor = 1.0 + scroll_delta * 0.001;
             state.zoom = (state.zoom * zoom_factor).clamp(0.1, 20.0);
         }
     }
+}
+
+/// Height of one panel in a column of `panel_count` stacked panels.
+fn column_height(available_height: f32, panel_count: usize) -> f32 {
+    let gaps = PANEL_MARGIN * (panel_count.saturating_sub(1)) as f32;
+    (available_height - gaps) / panel_count as f32
 }
 
 const TOAST_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
@@ -145,17 +181,6 @@ pub fn draw_main_content(ui: &mut egui::Ui) {
         ui.heading_with_margin("📁 Drop an image file here or use 'File > Open Image...'");
     });
 }
-#[derive(Clone)]
-struct ImagePanelSettings {
-    pub width: f32,
-    pub height: f32,
-    pub zoom: f32,
-    pub pan_offset: Vec2,
-    pub title: String,
-    pub has_spinner: bool,
-    pub overlay_text: Option<String>,
-}
-
 fn draw_background_and_pixels(painter: &egui::Painter, canvas: Rect, base_color: Color32) {
     painter.rect_filled(canvas, 0.0, base_color);
 
@@ -195,7 +220,7 @@ fn draw_background_and_pixels(painter: &egui::Painter, canvas: Rect, base_color:
 fn draw_main_image(
     painter: &egui::Painter,
     canvas: Rect,
-    image_data: &Option<crate::types::ImageData>,
+    image_data: &Option<ImageData>,
     zoom: f32,
     pan_offset: Vec2,
 ) {
@@ -269,49 +294,26 @@ fn draw_overlay_text(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Conte
     painter.galley(rect.center() - galley.size() * 0.5, galley, text_color);
 }
 
-fn draw_image_panel(
-    ui: &mut egui::Ui,
-    state: &AppState,
-    settings: ImagePanelSettings,
-    image_data: &Option<crate::types::ImageData>,
-    palettes_for_ui: Option<&Vec<Vec<egui::Color32>>>,
-    pan_changed: &mut Vec2,
-) {
+fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2) {
     ui.allocate_ui_with_layout(
-        Vec2::new(settings.width, settings.height),
+        panel.size,
         egui::Layout::top_down(egui::Align::Center),
         |ui| {
-            let (response, painter) = ui.allocate_painter(
-                Vec2::new(settings.width, settings.height),
-                egui::Sense::click_and_drag(),
-            );
+            let (response, painter) =
+                ui.allocate_painter(panel.size, egui::Sense::click_and_drag());
             let canvas = response.rect;
 
-            let base_color = state
-                .preferences
-                .background_color
-                .unwrap_or(Color32::from_gray(64));
+            draw_background_and_pixels(&painter, canvas, panel.background);
+            draw_main_image(&painter, canvas, panel.image, panel.zoom, panel.pan_offset);
+            draw_title(&painter, canvas, panel.title, ui.ctx());
 
-            draw_background_and_pixels(&painter, canvas, base_color);
-            draw_main_image(
-                &painter,
-                canvas,
-                image_data,
-                settings.zoom,
-                settings.pan_offset,
-            );
-            draw_title(&painter, canvas, &settings.title, ui.ctx());
-
-            if state.preferences.show_palettes
-                && let Some(palettes_for_ui) = palettes_for_ui
-            {
-                draw_palettes_overlay(&painter, canvas, palettes_for_ui);
+            if let Some(palettes) = panel.palettes {
+                draw_palettes_overlay(&painter, canvas, palettes);
             }
-
-            if settings.has_spinner {
+            if panel.has_spinner {
                 draw_spinner(&painter, canvas, ui.ctx());
             }
-            if let Some(text) = &settings.overlay_text {
+            if let Some(text) = panel.overlay_text {
                 draw_overlay_text(&painter, canvas, ui.ctx(), text);
             }
 
@@ -533,5 +535,34 @@ fn draw_single_palette(
             ),
             egui::StrokeKind::Middle,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_single_panel_fills_the_column() {
+        assert_eq!(column_height(400.0, 1), 400.0);
+    }
+
+    #[test]
+    fn two_panels_share_the_column_minus_the_gap() {
+        assert_eq!(column_height(404.0, 2), 200.0);
+    }
+
+    #[test]
+    fn columns_with_different_panel_counts_stay_within_the_view() {
+        let available = 500.0;
+        for panel_count in 1..=4 {
+            let height = column_height(available, panel_count);
+            let used =
+                height * panel_count as f32 + PANEL_MARGIN * panel_count.saturating_sub(1) as f32;
+            assert!(
+                (used - available).abs() < 1e-3,
+                "{panel_count} panels: {used}"
+            );
+        }
     }
 }

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -4,8 +4,7 @@ use egui::{Align2, Color32, FontId, Id, Pos2, Rect, Vec2};
 
 pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, image_processing: bool) {
     const HORIZONTAL_MARGIN: f32 = 4.0;
-    let mut available_size = ui.available_size();
-    available_size.y -= 34.0; // footer size
+    let available_size = ui.available_size();
 
     let zoom = state.zoom;
     let pan_offset = state.pan_offset;
@@ -71,37 +70,16 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, image_processing
 
         // Right panel
         if !state.tile_size_warning {
-            let palettes_for_ui =
-                if let Some(indexed_image) = &state.output_palette_sorted_indexed_image {
-                    Some(&indexed_image.palettes_for_ui)
-                } else if let Some(image) = &state.output_image {
-                    image
-                        .indexed
-                        .as_ref()
-                        .map(|indexed_image| &indexed_image.palettes_for_ui)
-                } else {
-                    None
-                };
+            let toast = live_toast(state, ui.ctx());
+
+            // Prefer the sorted palette when one is active.
+            let palettes_for_ui = state
+                .output_palette_sorted_indexed_image
+                .as_ref()
+                .or_else(|| state.output_image.as_ref().and_then(|i| i.indexed.as_ref()))
+                .map(|indexed| &indexed.palettes_for_ui);
             let tile_reduced = state.settings.tile_reduce_post_enabled
                 && (state.tile_reduce_processing || state.reduced_tile_count.is_some());
-            let toast = if let Some(toast) = &state.tile_reduce_toast {
-                if toast.time.elapsed() < std::time::Duration::from_secs(3) {
-                    Some(toast.message.clone())
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            if toast.is_none()
-                && state
-                    .tile_reduce_toast
-                    .as_ref()
-                    .map(|t| t.time.elapsed() >= std::time::Duration::from_secs(3))
-                    .unwrap_or(false)
-            {
-                let _ = state.tile_reduce_toast.take();
-            }
 
             let settings = ImagePanelSettings {
                 width: split_x,
@@ -144,6 +122,22 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, image_processing
             state.zoom = (state.zoom * zoom_factor).clamp(0.1, 20.0);
         }
     }
+}
+
+const TOAST_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Return the tile reduce toast while it is still within its display window,
+/// dropping it once it has expired. Schedules the repaint that makes it vanish.
+fn live_toast(state: &mut AppState, ctx: &egui::Context) -> Option<String> {
+    let toast = state.tile_reduce_toast.as_ref()?;
+    let Some(remaining) = TOAST_DURATION.checked_sub(toast.time.elapsed()) else {
+        state.tile_reduce_toast = None;
+        return None;
+    };
+
+    let message = toast.message.clone();
+    ctx.request_repaint_after(remaining);
+    Some(message)
 }
 
 pub fn draw_main_content(ui: &mut egui::Ui) {
@@ -293,13 +287,11 @@ fn draw_image_panel(
             );
             let canvas = response.rect;
 
-            // 背景色を取得
             let base_color = state
                 .preferences
                 .background_color
                 .unwrap_or(Color32::from_gray(64));
 
-            // 各要素を描画
             draw_background_and_pixels(&painter, canvas, base_color);
             draw_main_image(
                 &painter,
@@ -323,7 +315,7 @@ fn draw_image_panel(
                 draw_overlay_text(&painter, canvas, ui.ctx(), text);
             }
 
-            // パン操作の処理
+            // Panning
             if response.dragged() {
                 *pan_changed += response.drag_delta();
             }

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -529,7 +529,7 @@ fn draw_single_palette(
             color_rect,
             0.0,
             egui::Stroke::new(
-                1.0,
+                1.0_f32,
                 if hovered
                     .map(|(p_idx, c_idx)| p_idx == palette_idx && c_idx == color_idx)
                     .unwrap_or(false)

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -1,5 +1,5 @@
 use super::styles::UiMarginExt;
-use crate::types::{AppState, ImageData};
+use crate::types::{AppState, ImageData, app_state::Toast};
 use egui::{Align2, Color32, FontId, Id, Pos2, Rect, Vec2};
 
 /// Gap between the image panels.
@@ -8,19 +8,27 @@ const PANEL_MARGIN: f32 = 4.0;
 /// Everything one image panel needs to draw itself.
 struct ImagePanel<'a> {
     title: &'a str,
-    image: &'a Option<ImageData>,
+    image: Option<&'a ImageData>,
     size: Vec2,
     zoom: f32,
     pan_offset: Vec2,
     background: Color32,
     has_spinner: bool,
     overlay_text: Option<&'a str>,
+    /// Persistent warning drawn in the top left corner of the panel.
+    notice: Option<&'a str>,
     palettes: Option<&'a Vec<Vec<Color32>>>,
 }
 
 pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_processing: bool) {
     let available_size = ui.available_size();
-    let toast = live_toast(state, ui.ctx());
+    let toast = live_toast(&mut state.tile_reduce_toast, ui.ctx());
+    let fit_toast = live_toast(&mut state.tile_fit_toast, ui.ctx());
+    let fit_notice = state.tile_fit_notice();
+    // The Original view shows what the pipeline actually consumes, so the added
+    // border is visible right next to the notice explaining it, and all four
+    // panels share the same dimensions at a given zoom.
+    let original_image = state.processing_input();
 
     let zoom = state.zoom;
     let pan_offset = state.pan_offset;
@@ -64,13 +72,14 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                 ui,
                 ImagePanel {
                     title: "Original",
-                    image: &state.input_image,
+                    image: original_image,
                     size: Vec2::new(column_width, input_height),
                     zoom,
                     pan_offset,
                     background,
                     has_spinner: false,
-                    overlay_text: None,
+                    overlay_text: fit_toast.as_deref(),
+                    notice: fit_notice.as_deref(),
                     palettes: None,
                 },
                 &mut pan_changed,
@@ -81,13 +90,14 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                     ui,
                     ImagePanel {
                         title: "Color Corrected",
-                        image: &state.color_corrected_image,
+                        image: state.color_corrected_image.as_ref(),
                         size: Vec2::new(column_width, input_height),
                         zoom,
                         pan_offset,
                         background,
                         has_spinner: state.color_corrected_image.is_none(),
                         overlay_text: None,
+                        notice: None,
                         palettes: None,
                     },
                     &mut pan_changed,
@@ -95,12 +105,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
             }
         });
 
-        // Outputs, or the warning that replaces them
-        if state.tile_size_warning {
-            draw_status_panel(ui, state, column_width, available_size.y);
-            return;
-        }
-
+        // Outputs
         ui.vertical(|ui| {
             ui.style_mut().spacing.item_spacing = egui::vec2(0.0, PANEL_MARGIN);
 
@@ -108,13 +113,14 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                 ui,
                 ImagePanel {
                     title: "Qualetized",
-                    image: &state.base_output_image,
+                    image: state.base_output_image.as_ref(),
                     size: Vec2::new(column_width, output_height),
                     zoom,
                     pan_offset,
                     background,
                     has_spinner: qualetize_processing,
                     overlay_text: None,
+                    notice: None,
                     palettes,
                 },
                 &mut pan_changed,
@@ -125,7 +131,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                     ui,
                     ImagePanel {
                         title: "Tile Reduced",
-                        image: &state.output_image,
+                        image: state.output_image.as_ref(),
                         size: Vec2::new(column_width, output_height),
                         zoom,
                         pan_offset,
@@ -133,6 +139,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                         // A new quantization invalidates the reduced result too.
                         has_spinner: qualetize_processing || state.tile_reduce_processing,
                         overlay_text: toast.as_deref(),
+                        notice: None,
                         palettes: None,
                     },
                     &mut pan_changed,
@@ -162,12 +169,12 @@ fn column_height(available_height: f32, panel_count: usize) -> f32 {
 
 const TOAST_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
 
-/// Return the tile reduce toast while it is still within its display window,
-/// dropping it once it has expired. Schedules the repaint that makes it vanish.
-fn live_toast(state: &mut AppState, ctx: &egui::Context) -> Option<String> {
-    let toast = state.tile_reduce_toast.as_ref()?;
+/// Return a toast while it is still within its display window, dropping it once
+/// it has expired. Schedules the repaint that makes it vanish.
+fn live_toast(slot: &mut Option<Toast>, ctx: &egui::Context) -> Option<String> {
+    let toast = slot.as_ref()?;
     let Some(remaining) = TOAST_DURATION.checked_sub(toast.time.elapsed()) else {
-        state.tile_reduce_toast = None;
+        *slot = None;
         return None;
     };
 
@@ -220,7 +227,7 @@ fn draw_background_and_pixels(painter: &egui::Painter, canvas: Rect, base_color:
 fn draw_main_image(
     painter: &egui::Painter,
     canvas: Rect,
-    image_data: &Option<ImageData>,
+    image_data: Option<&ImageData>,
     zoom: f32,
     pan_offset: Vec2,
 ) {
@@ -237,31 +244,48 @@ fn draw_main_image(
     }
 }
 
+/// Warning color, matching the one used by the settings panel.
+const NOTICE_COLOR: Color32 = Color32::from_rgb(255, 180, 0);
+
+/// A small text chip drawn over the image, used for titles and notices.
+fn draw_label_chip(
+    painter: &egui::Painter,
+    ui_ctx: &egui::Context,
+    top_left: Pos2,
+    text: &str,
+    text_color: Color32,
+) {
+    let window_color = ui_ctx.global_style().visuals.window_fill();
+    let bg_color =
+        Color32::from_rgba_unmultiplied(window_color.r(), window_color.g(), window_color.b(), 178);
+
+    let galley =
+        ui_ctx.fonts_mut(|f| f.layout_no_wrap(text.to_string(), FontId::default(), text_color));
+    let rect = Rect::from_min_size(
+        top_left - egui::vec2(2.0, 1.0),
+        galley.size() + egui::vec2(4.0, 2.0),
+    );
+
+    painter.rect_filled(rect, 0.0, bg_color);
+    painter.galley(top_left, galley, text_color);
+}
+
 fn draw_title(painter: &egui::Painter, canvas: Rect, title: &str, ui_ctx: &egui::Context) {
     if title.is_empty() {
         return;
     }
 
-    let style = ui_ctx.global_style();
-    let visuals = &style.visuals;
-    let window_color = visuals.window_fill();
-    let bg_color =
-        Color32::from_rgba_unmultiplied(window_color.r(), window_color.g(), window_color.b(), 178);
+    let visuals = ui_ctx.global_style().visuals.clone();
     let text_color = visuals.override_text_color.unwrap_or(visuals.text_color());
-
-    let galley =
-        ui_ctx.fonts_mut(|f| f.layout_no_wrap(title.to_string(), FontId::default(), text_color));
-
     let pos = canvas.left_bottom() + Vec2::new(4.0, -20.0);
-    let rect = Align2::LEFT_TOP.align_size_within_rect(
-        galley.size() + egui::vec2(4.0, 2.0),
-        Rect::from_min_size(
-            pos - egui::vec2(2.0, 1.0),
-            galley.size() + egui::vec2(4.0, 2.0),
-        ),
-    );
-    painter.rect_filled(rect, 0.0, bg_color);
-    painter.galley(pos, galley, text_color);
+    draw_label_chip(painter, ui_ctx, pos, title, text_color);
+}
+
+/// Persistent notice in the top left corner, for state the user should keep
+/// seeing rather than a toast that fades.
+fn draw_notice(painter: &egui::Painter, canvas: Rect, text: &str, ui_ctx: &egui::Context) {
+    let pos = canvas.left_top() + Vec2::new(4.0, 4.0);
+    draw_label_chip(painter, ui_ctx, pos, text, NOTICE_COLOR);
 }
 
 fn draw_spinner(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Context) {
@@ -308,6 +332,9 @@ fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2
             draw_background_and_pixels(&painter, canvas, panel.background);
             draw_main_image(&painter, canvas, panel.image, panel.zoom, panel.pan_offset);
             draw_title(&painter, canvas, panel.title, ui.ctx());
+            if let Some(notice) = panel.notice {
+                draw_notice(&painter, canvas, notice, ui.ctx());
+            }
 
             if let Some(palettes) = panel.palettes {
                 draw_palettes_overlay(&painter, canvas, palettes);
@@ -324,54 +351,6 @@ fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2
                 *pan_changed += response.drag_delta();
             }
         },
-    );
-}
-
-fn draw_status_panel(ui: &mut egui::Ui, state: &AppState, width: f32, height: f32) {
-    ui.allocate_ui_with_layout(
-        Vec2::new(width, height),
-        egui::Layout::top_down(egui::Align::Center),
-        |ui| {
-            let (_, painter) = ui.allocate_painter(Vec2::new(width, height), egui::Sense::hover());
-
-            // Draw background
-            painter.rect_filled(painter.clip_rect(), 0.0, Color32::from_gray(64));
-
-            ui.scope_builder(
-                egui::UiBuilder::new().max_rect(Rect::from_center_size(
-                    painter.clip_rect().center(),
-                    Vec2::new(300.0, 150.0),
-                )),
-                |ui| {
-                    ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-                        if state.tile_size_warning {
-                            draw_warning_message(ui, state);
-                        }
-                    });
-                },
-            );
-        },
-    );
-}
-
-fn draw_warning_message(ui: &mut egui::Ui, state: &AppState) {
-    ui.label(egui::RichText::new("⚠").size(32.0).color(Color32::YELLOW));
-    ui.label(
-        egui::RichText::new("Tile Size Warning")
-            .size(16.0)
-            .color(Color32::YELLOW),
-    );
-    ui.add_space(10.0);
-    ui.label(
-        egui::RichText::new(state.tile_size_warning_message())
-            .size(12.0)
-            .color(Color32::WHITE),
-    );
-    ui.add_space(10.0);
-    ui.label(
-        egui::RichText::new("Adjust tile width/height in settings to match image dimensions.")
-            .size(11.0)
-            .color(Color32::LIGHT_GRAY),
     );
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,28 +4,7 @@ mod image_viewer;
 mod settings_panel;
 pub mod styles;
 
-use crate::types::AppState;
-
-pub struct UI;
-
-impl UI {
-    pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
-        settings_panel::draw_settings_panel(ui, state)
-    }
-
-    pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, image_processing: bool) {
-        image_viewer::draw_image_view(ui, state, image_processing)
-    }
-
-    pub fn draw_main_content(ui: &mut egui::Ui) {
-        image_viewer::draw_main_content(ui)
-    }
-
-    pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> bool {
-        header::draw_header(ui, state)
-    }
-
-    pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) {
-        footer::draw_footer(ui, state)
-    }
-}
+pub use footer::draw_footer;
+pub use header::draw_header;
+pub use image_viewer::{draw_image_view, draw_main_content};
+pub use settings_panel::draw_settings_panel;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,7 +25,7 @@ impl UI {
         header::draw_header(ui, state)
     }
 
-    pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) -> bool {
+    pub fn draw_footer(ui: &mut egui::Ui, state: &mut AppState) {
         footer::draw_footer(ui, state)
     }
 }

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -9,6 +9,7 @@ use crate::types::{
     image::{SortMode, SortOrder},
 };
 use egui::Color32;
+use std::ops::RangeInclusive;
 
 pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
     let mut settings_changed = false;
@@ -499,245 +500,177 @@ fn draw_clustering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     settings_changed
 }
 
+/// Height of one row in the color correction grid.
+const ROW_HEIGHT: f32 = 24.0;
+
+const BRIGHTNESS_RANGE: RangeInclusive<f32> = -1.0..=1.0;
+const CONTRAST_RANGE: RangeInclusive<f32> = 0.0..=2.0;
+const SATURATION_RANGE: RangeInclusive<f32> = 0.0..=2.0;
+const HUE_SHIFT_RANGE: RangeInclusive<f32> = -180.0..=180.0;
+const SHADOWS_RANGE: RangeInclusive<f32> = -1.0..=1.0;
+const HIGHLIGHTS_RANGE: RangeInclusive<f32> = -1.0..=1.0;
+const GAMMA_RANGE: RangeInclusive<f32> = 0.1..=3.0;
+const GAMMA_DISPLAY_RANGE: RangeInclusive<f32> = -100.0..=100.0;
+
+/// How the numeric field next to a color correction slider is shown and parsed.
+#[derive(Clone, Copy)]
+enum ValueFormat {
+    /// `0.5` is shown as `+50%`; both `50%` and `0.5` are accepted as input.
+    Percentage,
+    /// Plain number with two decimals.
+    Decimal,
+    /// Whole degrees with a `°` suffix.
+    Degrees,
+}
+
+impl ValueFormat {
+    fn drag_speed(self) -> f64 {
+        match self {
+            ValueFormat::Percentage | ValueFormat::Decimal => 0.01,
+            ValueFormat::Degrees => 1.0,
+        }
+    }
+
+    fn apply(self, drag: egui::DragValue<'_>) -> egui::DragValue<'_> {
+        match self {
+            ValueFormat::Percentage => drag
+                .custom_formatter(|n, _| format_percentage(n as f32))
+                .custom_parser(parse_percentage),
+            ValueFormat::Decimal => drag.fixed_decimals(2),
+            ValueFormat::Degrees => drag.suffix("°").fixed_decimals(0),
+        }
+    }
+}
+
+/// Accepts either a percentage (`-50%`) or the raw factor (`-0.5`).
+fn parse_percentage(text: &str) -> Option<f64> {
+    match text.strip_suffix('%') {
+        Some(number) => number.parse::<f64>().ok().map(|value| value / 100.0),
+        None => text.parse::<f64>().ok(),
+    }
+}
+
+fn draw_row_label(ui: &mut egui::Ui, label: &str) {
+    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+        ui.label(format!("{label}:"));
+    });
+}
+
+/// One `label | slider | number` row of the color correction grid.
+/// Returns true if the value was edited.
+fn draw_slider_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    value: &mut f32,
+    range: RangeInclusive<f32>,
+    format: ValueFormat,
+    slider_width: f32,
+) -> bool {
+    draw_row_label(ui, label);
+
+    let mut changed = ui
+        .add_sized(
+            [slider_width, ROW_HEIGHT],
+            egui::Slider::new(value, range.clone()).show_value(false),
+        )
+        .changed();
+
+    let drag = egui::DragValue::new(value)
+        .range(range)
+        .speed(format.drag_speed());
+    changed |= ui.add(format.apply(drag)).changed();
+
+    ui.end_row();
+    changed
+}
+
+/// Gamma needs its own row: the slider edits an intuitive -100..100 display
+/// value while the number field edits the gamma exponent directly.
+fn draw_gamma_row(ui: &mut egui::Ui, gamma: &mut f32, slider_width: f32) -> bool {
+    draw_row_label(ui, "Gamma");
+
+    let mut changed = false;
+    let mut display = gamma_to_display_value(*gamma);
+    if ui
+        .add_sized(
+            [slider_width, ROW_HEIGHT],
+            egui::Slider::new(&mut display, GAMMA_DISPLAY_RANGE).show_value(false),
+        )
+        .changed()
+    {
+        *gamma = display_value_to_gamma(display);
+        changed = true;
+    }
+
+    changed |= ui
+        .add(
+            egui::DragValue::new(gamma)
+                .range(GAMMA_RANGE)
+                .speed(0.01)
+                .custom_formatter(|n, _| format_gamma(n as f32))
+                .custom_parser(|s| s.parse::<f64>().ok()),
+        )
+        .changed();
+
+    ui.end_row();
+    changed
+}
+
 fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
 
     ui.heading_with_margin("Color Correction");
 
-    // Define ranges to avoid duplication
-    const BRIGHTNESS_RANGE: std::ops::RangeInclusive<f32> = -1.0..=1.0;
-    const CONTRAST_RANGE: std::ops::RangeInclusive<f32> = 0.0..=2.0;
-    const SATURATION_RANGE: std::ops::RangeInclusive<f32> = 0.0..=2.0;
-    const HUE_SHIFT_RANGE: std::ops::RangeInclusive<f32> = -180.0..=180.0;
-    const SHADOWS_RANGE: std::ops::RangeInclusive<f32> = -1.0..=1.0;
-    const HIGHLIGHTS_RANGE: std::ops::RangeInclusive<f32> = -1.0..=1.0;
-    const GAMMA_RANGE: std::ops::RangeInclusive<f32> = 0.1..=3.0;
-    const GAMMA_DISPLAY_RANGE: std::ops::RangeInclusive<f32> = -100.0..=100.0;
-
     egui::Grid::new("color_correction_grid")
         .num_columns(3)
         .spacing([4.0, 6.0])
         .show(ui, |ui| {
-            let available_width = ui.available_width();
-            let slider_width = (available_width * 0.6).max(180.0);
-
+            let slider_width = (ui.available_width() * 0.6).max(180.0);
             ui.style_mut().spacing.slider_width = slider_width;
 
-            // Brightness
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Brightness:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.brightness, BRIGHTNESS_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.brightness)
-                        .range(BRIGHTNESS_RANGE)
-                        .speed(0.01)
-                        .custom_formatter(|n, _| format_percentage(n as f32))
-                        .custom_parser(|s| {
-                            // Try to parse as percentage first
-                            if let Some(s) = s.strip_suffix('%') {
-                                s.parse::<f64>().map(|v| v / 100.0).ok()
-                            } else {
-                                s.parse::<f64>().ok()
-                            }
-                        }),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
+            let correction = &mut state.color_correction;
+            let mut row = |label, value: &mut f32, range, format| {
+                draw_slider_row(ui, label, value, range, format, slider_width)
+            };
 
-            // Contrast
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Contrast:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.contrast, CONTRAST_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.contrast)
-                        .range(CONTRAST_RANGE)
-                        .speed(0.01)
-                        .fixed_decimals(2),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
+            settings_changed |= row(
+                "Brightness",
+                &mut correction.brightness,
+                BRIGHTNESS_RANGE,
+                ValueFormat::Percentage,
+            );
+            settings_changed |= row(
+                "Contrast",
+                &mut correction.contrast,
+                CONTRAST_RANGE,
+                ValueFormat::Decimal,
+            );
+            settings_changed |= row(
+                "Saturation",
+                &mut correction.saturation,
+                SATURATION_RANGE,
+                ValueFormat::Decimal,
+            );
+            settings_changed |= row(
+                "Hue Shift",
+                &mut correction.hue_shift,
+                HUE_SHIFT_RANGE,
+                ValueFormat::Degrees,
+            );
+            settings_changed |= row(
+                "Shadows",
+                &mut correction.shadows,
+                SHADOWS_RANGE,
+                ValueFormat::Percentage,
+            );
+            settings_changed |= row(
+                "Highlights",
+                &mut correction.highlights,
+                HIGHLIGHTS_RANGE,
+                ValueFormat::Percentage,
+            );
 
-            // Saturation
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Saturation:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.saturation, SATURATION_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.saturation)
-                        .range(SATURATION_RANGE)
-                        .speed(0.01)
-                        .fixed_decimals(2),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
-
-            // Hue Shift
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Hue Shift:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.hue_shift, HUE_SHIFT_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.hue_shift)
-                        .range(HUE_SHIFT_RANGE)
-                        .speed(1.0)
-                        .suffix("°")
-                        .fixed_decimals(0),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
-
-            // Shadows
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Shadows:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.shadows, SHADOWS_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.shadows)
-                        .range(SHADOWS_RANGE)
-                        .speed(0.01)
-                        .custom_formatter(|n, _| format_percentage(n as f32))
-                        .custom_parser(|s| {
-                            // Try to parse as percentage first
-                            if let Some(s) = s.strip_suffix('%') {
-                                s.parse::<f64>().map(|v| v / 100.0).ok()
-                            } else {
-                                s.parse::<f64>().ok()
-                            }
-                        }),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
-
-            // Highlights
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Highlights:");
-            });
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut state.color_correction.highlights, HIGHLIGHTS_RANGE)
-                        .show_value(false),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.highlights)
-                        .range(HIGHLIGHTS_RANGE)
-                        .speed(0.01)
-                        .custom_formatter(|n, _| format_percentage(n as f32))
-                        .custom_parser(|s| {
-                            // Try to parse as percentage first
-                            if let Some(s) = s.strip_suffix('%') {
-                                s.parse::<f64>().map(|v| v / 100.0).ok()
-                            } else {
-                                s.parse::<f64>().ok()
-                            }
-                        }),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
-
-            // Gamma (special handling)
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("Gamma:");
-            });
-            let mut gamma_display = gamma_to_display_value(state.color_correction.gamma);
-            if ui
-                .add_sized(
-                    [slider_width, 24.0],
-                    egui::Slider::new(&mut gamma_display, GAMMA_DISPLAY_RANGE).show_value(false),
-                )
-                .changed()
-            {
-                state.color_correction.gamma = display_value_to_gamma(gamma_display);
-                settings_changed = true;
-            }
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.color_correction.gamma)
-                        .range(GAMMA_RANGE)
-                        .speed(0.01)
-                        .custom_formatter(|n, _| format_gamma(n as f32))
-                        .custom_parser(|s| s.parse::<f64>().ok()),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            ui.end_row();
+            settings_changed |= draw_gamma_row(ui, &mut correction.gamma, slider_width);
         });
 
     // Color correction presets
@@ -755,7 +688,7 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bo
 
         for (label, preset) in presets {
             if ui
-                .add_sized([button_width, 24.0], egui::Button::new(label))
+                .add_sized([button_width, ROW_HEIGHT], egui::Button::new(label))
                 .clicked()
             {
                 state.color_correction = preset;

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -865,3 +865,30 @@ fn draw_palette_sort_settings(ui: &mut egui::Ui, state: &mut AppState) {
         });
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_rgba_depths_report_no_error() {
+        for depth in ["8888", "5551", "3331", "1111"] {
+            assert!(validate_rgba_depth(depth), "{depth} should be valid");
+            assert_eq!(get_rgba_depth_error(depth), None, "{depth}");
+        }
+    }
+
+    #[test]
+    fn invalid_rgba_depths_report_an_error() {
+        for depth in ["", "888", "88888", "8x88", "0888", "8898"] {
+            assert!(!validate_rgba_depth(depth), "{depth} should be invalid");
+            assert!(get_rgba_depth_error(depth).is_some(), "{depth}");
+        }
+    }
+
+    #[test]
+    fn rgba_depth_error_names_the_offending_channel() {
+        assert!(get_rgba_depth_error("88x8").unwrap().starts_with('B'));
+        assert!(get_rgba_depth_error("0888").unwrap().starts_with('R'));
+    }
+}

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -186,7 +186,7 @@ fn draw_custom_level_inputs(ui: &mut egui::Ui, state: &mut AppState) -> bool {
                 ui.painter().rect_stroke(
                     response.rect,
                     2.0,
-                    egui::Stroke::new(1.0, Color32::from_rgb(255, 150, 150)),
+                    egui::Stroke::new(1.0_f32, Color32::from_rgb(255, 150, 150)),
                     egui::StrokeKind::Outside,
                 );
             }
@@ -253,7 +253,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             ui.painter().rect_stroke(
                 response.rect,
                 2.0,
-                egui::Stroke::new(1.0, Color32::from_rgb(255, 150, 150)),
+                egui::Stroke::new(1.0_f32, Color32::from_rgb(255, 150, 150)),
                 egui::StrokeKind::Outside,
             );
         }
@@ -330,7 +330,7 @@ fn draw_color_space_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         .show_ui(ui, |ui| {
             for color_space in ColorSpace::all() {
                 if ui
-                    .selectable_value(&mut state.settings.color_space, color_space.clone(), color_space.display_name())
+                    .selectable_value(&mut state.settings.color_space, *color_space, color_space.display_name())
                     .on_hover_text(color_space.description())
                     .clicked()
                 {
@@ -353,7 +353,7 @@ fn draw_dithering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         .show_ui(ui, |ui| {
             for dither_mode in DitherMode::all() {
                 if ui
-                    .selectable_value(&mut state.settings.dither_mode, dither_mode.clone(), dither_mode.display_name())
+                    .selectable_value(&mut state.settings.dither_mode, *dither_mode, dither_mode.display_name())
                     .on_hover_text(dither_mode.description())
                     .clicked()
                 {
@@ -778,7 +778,7 @@ fn draw_palette_sort_settings(ui: &mut egui::Ui, state: &mut AppState) {
                 for sort_mode in SortMode::all() {
                     ui.selectable_value(
                         &mut state.palette_sort_settings.mode,
-                        sort_mode.clone(),
+                        *sort_mode,
                         sort_mode.display_name(),
                     );
                 }
@@ -790,7 +790,7 @@ fn draw_palette_sort_settings(ui: &mut egui::Ui, state: &mut AppState) {
                     for sort_order in SortOrder::all() {
                         ui.selectable_value(
                             &mut state.palette_sort_settings.order,
-                            sort_order.clone(),
+                            *sort_order,
                             sort_order.display_name(),
                         );
                     }

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -11,6 +11,9 @@ use crate::types::{
 use egui::Color32;
 use std::ops::RangeInclusive;
 
+/// Channel names in the order they appear in an RGBA depth string.
+const RGBA_CHANNELS: [&str; 4] = ["R", "G", "B", "A"];
+
 pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
     let mut settings_changed = false;
     let mut tile_reduce_changed = false;
@@ -171,8 +174,7 @@ fn draw_custom_level_inputs(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
     ui.label("Per-channel levels (0-255, comma separated, max 255 entries)");
 
-    let channel_labels = ["R", "G", "B", "A"];
-    for (idx, label) in channel_labels.iter().enumerate() {
+    for (idx, label) in RGBA_CHANNELS.iter().enumerate() {
         ui.horizontal(|ui| {
             ui.label(format!("{label}:"));
             let mut response = ui.add_sized(
@@ -240,7 +242,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     if state.settings.use_custom_levels {
         settings_changed |= draw_custom_level_inputs(ui, state);
     } else {
-        let is_valid = validate_rgba_depth(&state.settings.rgba_depth);
+        let error = get_rgba_depth_error(&state.settings.rgba_depth);
         let is_empty = state.settings.rgba_depth.is_empty();
 
         let mut response = ui.add_sized(
@@ -248,7 +250,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             egui::TextEdit::singleline(&mut state.settings.rgba_depth),
         );
 
-        if !is_valid && !is_empty {
+        if error.is_some() && !is_empty {
             response = response.highlight();
             ui.painter().rect_stroke(
                 response.rect,
@@ -266,7 +268,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             settings_changed = true;
         }
 
-        if let Some(error) = get_rgba_depth_error(&state.settings.rgba_depth) {
+        if let Some(error) = error {
             ui.label(egui::RichText::new("⚠").color(Color32::from_rgb(255, 180, 0)))
                 .on_hover_text(format!("{error}\nExamples: 8888, 5551, 3331"));
         }
@@ -727,41 +729,26 @@ fn draw_status_section(ui: &mut egui::Ui, state: &AppState) {
 }
 
 /// Exactly 4 digits, each from 1-8.
-fn validate_rgba_depth(rgba_str: &str) -> bool {
-    rgba_str.len() == 4 && rgba_str.bytes().all(|b| (b'1'..=b'8').contains(&b))
-}
-
+/// Returns the reason `rgba_str` is not a valid RGBA depth, or `None` if it is.
 fn get_rgba_depth_error(rgba_str: &str) -> Option<String> {
     if rgba_str.is_empty() {
         return Some("RGBA depth is required".to_string());
     }
 
-    if rgba_str.len() != 4 {
-        return Some(format!("Expected 4 digits, got {}", rgba_str.len()));
+    let digit_count = rgba_str.chars().count();
+    if digit_count != RGBA_CHANNELS.len() {
+        return Some(format!(
+            "Expected {} digits, got {digit_count}",
+            RGBA_CHANNELS.len()
+        ));
     }
 
-    for (i, ch) in rgba_str.chars().enumerate() {
-        if !ch.is_ascii_digit() {
-            let component = match i {
-                0 => "R",
-                1 => "G",
-                2 => "B",
-                3 => "A",
-                _ => "?",
-            };
-            return Some(format!("{component} component '{ch}' is not a digit"));
-        }
-
-        let digit = ch.to_digit(10).unwrap();
+    for (channel, ch) in RGBA_CHANNELS.iter().zip(rgba_str.chars()) {
+        let Some(digit) = ch.to_digit(10) else {
+            return Some(format!("{channel} component '{ch}' is not a digit"));
+        };
         if !(1..=8).contains(&digit) {
-            let component = match i {
-                0 => "R",
-                1 => "G",
-                2 => "B",
-                3 => "A",
-                _ => "?",
-            };
-            return Some(format!("{component} component {digit} must be 1-8"));
+            return Some(format!("{channel} component {digit} must be 1-8"));
         }
     }
 
@@ -806,16 +793,17 @@ mod tests {
     #[test]
     fn valid_rgba_depths_report_no_error() {
         for depth in ["8888", "5551", "3331", "1111"] {
-            assert!(validate_rgba_depth(depth), "{depth} should be valid");
-            assert_eq!(get_rgba_depth_error(depth), None, "{depth}");
+            assert_eq!(get_rgba_depth_error(depth), None, "{depth} should be valid");
         }
     }
 
     #[test]
     fn invalid_rgba_depths_report_an_error() {
         for depth in ["", "888", "88888", "8x88", "0888", "8898"] {
-            assert!(!validate_rgba_depth(depth), "{depth} should be invalid");
-            assert!(get_rgba_depth_error(depth).is_some(), "{depth}");
+            assert!(
+                get_rgba_depth_error(depth).is_some(),
+                "{depth} should be invalid"
+            );
         }
     }
 

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -398,62 +398,60 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         settings_changed = true;
     }
 
-    ui.add_enabled_ui(state.settings.tile_reduce_post_enabled, |ui| {
-        ui.horizontal(|ui| {
-            if ui
-                .checkbox(
-                    &mut state.settings.tile_reduce_allow_flip_x,
-                    "Allowed X Flips",
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-            if ui
-                .checkbox(
-                    &mut state.settings.tile_reduce_allow_flip_y,
-                    "Allowed Y Flips",
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-        });
+    // The settings only exist once the pass is turned on.
+    if !state.settings.tile_reduce_post_enabled {
+        return settings_changed;
+    }
 
-        ui.horizontal(|ui| {
-            ui.label("Threshold:")
-                .on_hover_text("Average per-channel MSE per pixel after quantization.");
-
-            let slider =
-                egui::Slider::new(&mut state.settings.tile_reduce_post_threshold, 1.0..=500.0)
-                    .logarithmic(false)
-                    .show_value(false);
-            if ui.add(slider).changed() {
-                settings_changed = true;
-            }
-
-            if ui
-                .add(
-                    egui::DragValue::new(&mut state.settings.tile_reduce_post_threshold)
-                        .range(1.0..=500.0)
-                        .speed(5.0),
-                )
-                .changed()
-            {
-                settings_changed = true;
-            }
-        });
-
-        let reduced_text = if let (Some(base), Some(reduced)) =
-            (state.base_tile_count, state.reduced_tile_count)
+    ui.horizontal(|ui| {
+        if ui
+            .checkbox(
+                &mut state.settings.tile_reduce_allow_flip_x,
+                "Allowed X Flips",
+            )
+            .changed()
         {
-            let diff = base.saturating_sub(reduced);
-            format!("Reduced {} tiles", diff)
-        } else {
-            "Reduced -- tiles".to_string()
-        };
-        ui.label(egui::RichText::new(reduced_text).strong());
+            settings_changed = true;
+        }
+        if ui
+            .checkbox(
+                &mut state.settings.tile_reduce_allow_flip_y,
+                "Allowed Y Flips",
+            )
+            .changed()
+        {
+            settings_changed = true;
+        }
     });
+
+    ui.horizontal(|ui| {
+        ui.label("Threshold:")
+            .on_hover_text("Average per-channel MSE per pixel after quantization.");
+
+        let slider = egui::Slider::new(&mut state.settings.tile_reduce_post_threshold, 1.0..=500.0)
+            .logarithmic(false)
+            .show_value(false);
+        if ui.add(slider).changed() {
+            settings_changed = true;
+        }
+
+        if ui
+            .add(
+                egui::DragValue::new(&mut state.settings.tile_reduce_post_threshold)
+                    .range(1.0..=500.0)
+                    .speed(5.0),
+            )
+            .changed()
+        {
+            settings_changed = true;
+        }
+    });
+
+    let reduced_text = match (state.base_tile_count, state.reduced_tile_count) {
+        (Some(base), Some(reduced)) => format!("Reduced {} tiles", base.saturating_sub(reduced)),
+        _ => "Reduced -- tiles".to_string(),
+    };
+    ui.label(egui::RichText::new(reduced_text).strong());
 
     settings_changed
 }
@@ -623,6 +621,21 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bo
 
     ui.heading_with_margin("Color Correction");
 
+    if ui
+        .checkbox(&mut state.color_correction.enabled, "Enable")
+        .on_hover_text(
+            "Adjust the image before quantization.\nWhen off the input image is passed through untouched.",
+        )
+        .changed()
+    {
+        settings_changed = true;
+    }
+
+    // The settings only exist once the pass is turned on.
+    if !state.color_correction.enabled {
+        return settings_changed;
+    }
+
     egui::Grid::new("color_correction_grid")
         .num_columns(3)
         .spacing([4.0, 6.0])
@@ -693,7 +706,7 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bo
                 .add_sized([button_width, ROW_HEIGHT], egui::Button::new(label))
                 .clicked()
             {
-                state.color_correction = preset;
+                state.color_correction.apply_preset(preset);
                 settings_changed = true;
             }
         }

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -452,6 +452,16 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     };
     ui.label(egui::RichText::new(reduced_text).strong());
 
+    ui.add_space(4.0);
+    if ui
+        .add_sized([80.0, ROW_HEIGHT], egui::Button::new("🔄 Reset"))
+        .on_hover_text("Restore the threshold and flip options to their defaults")
+        .clicked()
+    {
+        state.settings.reset_tile_reduce();
+        settings_changed = true;
+    }
+
     settings_changed
 }
 

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -1,4 +1,4 @@
-use super::styles::UiMarginExt;
+use super::styles::{UiMarginExt, error_color, warning_color};
 use crate::color_processor::{
     display_value_to_gamma, format_gamma, format_percentage, gamma_to_display_value,
 };
@@ -8,7 +8,6 @@ use crate::types::{
     color_correction::ColorCorrection,
     image::{SortMode, SortOrder},
 };
-use egui::Color32;
 use std::ops::RangeInclusive;
 
 /// Channel names in the order they appear in an RGBA depth string.
@@ -188,7 +187,7 @@ fn draw_custom_level_inputs(ui: &mut egui::Ui, state: &mut AppState) -> bool {
                 ui.painter().rect_stroke(
                     response.rect,
                     2.0,
-                    egui::Stroke::new(1.0_f32, Color32::from_rgb(255, 150, 150)),
+                    egui::Stroke::new(1.0_f32, error_color(ui.visuals())),
                     egui::StrokeKind::Outside,
                 );
             }
@@ -199,7 +198,7 @@ fn draw_custom_level_inputs(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             settings_changed |= response.changed();
 
             if !is_valid {
-                ui.label(egui::RichText::new("⚠").color(Color32::from_rgb(255, 180, 0)))
+                ui.label(egui::RichText::new("⚠").color(warning_color(ui.visuals())))
                     .on_hover_text(
                         "Enter comma-separated integers between 0 and 255 (max 255 entries)",
                     );
@@ -255,7 +254,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             ui.painter().rect_stroke(
                 response.rect,
                 2.0,
-                egui::Stroke::new(1.0_f32, Color32::from_rgb(255, 150, 150)),
+                egui::Stroke::new(1.0_f32, error_color(ui.visuals())),
                 egui::StrokeKind::Outside,
             );
         }
@@ -269,7 +268,7 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         }
 
         if let Some(error) = error {
-            ui.label(egui::RichText::new("⚠").color(Color32::from_rgb(255, 180, 0)))
+            ui.label(egui::RichText::new("⚠").color(warning_color(ui.visuals())))
                 .on_hover_text(format!("{error}\nExamples: 8888, 5551, 3331"));
         }
     }

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -9,7 +9,6 @@ use crate::types::{
     image::{SortMode, SortOrder},
 };
 use egui::Color32;
-use regex::Regex;
 
 pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
     let mut settings_changed = false;
@@ -794,14 +793,9 @@ fn draw_status_section(ui: &mut egui::Ui, state: &AppState) {
     ));
 }
 
+/// Exactly 4 digits, each from 1-8.
 fn validate_rgba_depth(rgba_str: &str) -> bool {
-    if rgba_str.is_empty() {
-        return false;
-    }
-
-    // Regex to match exactly 4 digits, each from 1-8
-    let re = Regex::new(r"^[1-8]{4}$").unwrap();
-    re.is_match(rgba_str)
+    rgba_str.len() == 4 && rgba_str.bytes().all(|b| (b'1'..=b'8').contains(&b))
 }
 
 fn get_rgba_depth_error(rgba_str: &str) -> Option<String> {

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -2,6 +2,26 @@ use egui::Color32;
 pub const COLOR_TINT: Color32 = Color32::from_rgb(240, 100, 156);
 pub const COLOR_TINT_ACTIVE: Color32 = Color32::from_rgb(131, 100, 144);
 
+/// Amber used for warnings. The bright variant is only readable against a dark
+/// background; on a light one it washes out, so light themes get a darker one.
+pub fn warning_color(visuals: &egui::Visuals) -> Color32 {
+    if visuals.dark_mode {
+        Color32::from_rgb(255, 180, 0)
+    } else {
+        Color32::from_rgb(150, 85, 0)
+    }
+}
+
+/// Red marking invalid input, darkened for light themes for the same reason as
+/// [`warning_color`].
+pub fn error_color(visuals: &egui::Visuals) -> Color32 {
+    if visuals.dark_mode {
+        Color32::from_rgb(255, 150, 150)
+    } else {
+        Color32::from_rgb(180, 40, 40)
+    }
+}
+
 pub fn init_styles(ctx: &egui::Context) {
     let mut fonts = egui::FontDefinitions::default();
 


### PR DESCRIPTION
Audit of the codebase followed by the fixes and features that came out of it. 19 commits, reviewable one at a time.

## User visible changes

**Tile grid**
- An image whose size is not a multiple of the tile size is now extended to the next multiple, anchored top left and filled with the top-left pixel color, instead of being refused. The loaded image is never modified; the extension is re-derived whenever the tile size changes. The Original view shows the extended image with a persistent amber notice naming both sizes.

**Views**
- Four panels in a 2x2 grid: Original / Color Corrected on the left, Qualetized / Tile Reduced on the right. Qualetized shows the raw quantization and Tile Reduced the merged result, so the two passes can be compared.
- The optional panels appear exactly when their pass is enabled, so `View > Canvas`'s Original / Color Corrected toggles are gone.

**Color Correction**
- Gains an Enable checkbox mirroring Tile Reduction. When off the input is passed through untouched. Both sections now hide their settings until enabled rather than greying them out.

**Export**
- `Export Image` names the pipeline stage rather than the encoding: Color Corrected PNG / Qualetized PNG / Qualetized BMP / Tile Reduced PNG / Tile Reduced BMP, each disabled unless its pass is enabled. Previously both indexed entries wrote the final image, so there was no way to export the un-reduced quantization.

**Settings**
- Qualetize settings, color correction and palette sort persist across restarts in `session.qset` next to `preferences.json`.
- `Edit > Reset Qualetize` no longer resets tile reduction with it; tile reduction gets its own Reset button and `Edit > Reset Tile Reduction`.

## Bug fixes

- `hero.idle.png` exported as `hero.png`: `with_extension` treated everything after the last dot of the new name as an extension, dropping the suffix and part of the stem.
- `Save Settings...` opened a *pick* dialog, so settings could only overwrite an existing `.qset` and could not be saved at all on first use.
- The whole indexed image was deep-cloned every frame, because the palette sort guard could never fire for the default `SortMode::None`.
- `Regex::new` ran up to five times per frame while the settings panel was visible.
- Corrected channels were truncated rather than rounded, biasing every channel downwards.
- Warning amber and error red were fixed colors picked for a dark background and washed out in light themes.

## Dependencies

- qualetize submodule -> `f040ee0`: uninitialised cluster list heads, and garbage palette indices when every tile is blank.
- egui/eframe 0.32 -> 0.35. `App::update(&Context)` became `App::ui(&mut Ui)`, `TopBottomPanel`/`SidePanel` merged into `Panel`, and panels attach to a `Ui`.
- rfd 0.15 -> 0.17, plus `cargo update`. `cc` pinned to 1.4 instead of `*`.

## Refactoring

Production code is about 150 lines smaller while test coverage went from 1 test to 43. The seven duplicated color correction slider blocks, the four duplicated file dialog arms and the three duplicated state resets are each one helper now. `clippy --all-targets -- -D warnings` is clean.

Two hot paths got faster: palette sorting walked the pixel buffer once per palette and now does one pass over a global remap table, and gamma/brightness/contrast collapsed into a 256 entry tone curve, removing three `powf` per pixel from the pass that runs while a slider is being dragged. The tone curve is asserted bit-exact against the original formula.

## Compatibility

No config file breaks: nothing uses `deny_unknown_fields`, so old `preferences.json` and `.qset` files still load, and files written by this version still load in 0.4.x. A `.qset` predating the color correction `enabled` flag loads as enabled, since correction was unconditional when it was written.

## Note

Tagged v0.4.3 was built while `Cargo.toml` still said `0.4.2`, so that release embedded the wrong version. This bump to 0.5.0 closes that drift.
