### PR TITLE
Review cleanup, cursor zoom, and settings panel toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "qualetize_gui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qualetize_gui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 build = "build.rs"
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,11 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    // Declared unconditionally so `rustc`'s cfg checker (`-Zcheck-cfg`, on by
+    // default since Rust 1.80) doesn't warn about `qualetize_sse` on targets
+    // where it's never actually set below.
+    println!("cargo:rustc-check-cfg=cfg(qualetize_sse)");
+
     let host = env::var("HOST").unwrap();
     let target = env::var("TARGET").unwrap();
 
@@ -17,7 +22,6 @@ fn main() {
     build
         .files([
             "external/qualetize/source/Qualetize.c",
-            "external/qualetize/source/qualetize-cli.c",
             "external/qualetize/source/Bitmap.c",
             "external/qualetize/source/Cluster.c",
             "external/qualetize/source/Cluster_Vec4f.c",
@@ -36,6 +40,10 @@ fn main() {
     if target.contains("x86_64") {
         build.flag("-msse");
         build.flag("-msse2");
+        // Mirrors `-msse`/`-msse2` above so Rust's `Vec4f` alignment (which the C
+        // header ties to `__SSE__`) matches the C side of the ABI. See
+        // `src/types/qualetize.rs`.
+        println!("cargo:rustc-cfg=qualetize_sse");
     }
 
     if host != target {

--- a/examples/genesis.qset
+++ b/examples/genesis.qset
@@ -22,6 +22,7 @@
     ]
   },
   "color_correction": {
+    "enabled": false,
     "brightness": 0.0,
     "contrast": 1.0,
     "gamma": 1.0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,55 +1,39 @@
 use std::path::Path;
 
 use crate::exporter::{save_indexed_bmp, save_indexed_png, save_rgba_image};
-use crate::image_processor::ImageProcessor;
+use crate::image_processor::{ImageProcessor, TileReduceOptions};
 use crate::settings_manager::SettingsBundle;
 use crate::types::ImageData;
-use crate::types::app_state::{
-    AppStateRequest, AppearanceMode, ExportSource, FittedInput, QualetizeRequest, Toast,
-};
-use crate::types::image::{ImageDataIndexed, SortMode, TileCountOptions};
+use crate::types::app_state::{AppStateRequest, AppearanceMode, ExportSource, FittedInput, Toast};
+use crate::types::image::{ImageDataIndexed, SortMode};
 use crate::types::{AppState, ExportFormat};
 use crate::ui::{
     draw_footer, draw_header, draw_image_view, draw_main_content, draw_settings_panel,
 };
 use eframe::egui;
-use egui::{ColorImage, Margin};
+use egui::Margin;
 use rfd::FileDialog;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 
+#[derive(Default)]
 pub struct QualetizeApp {
     state: AppState,
     image_processor: ImageProcessor,
 }
 
-impl Default for QualetizeApp {
-    fn default() -> Self {
-        Self {
-            state: AppState::default(),
-            image_processor: ImageProcessor::new(),
-        }
-    }
-}
-
 impl QualetizeApp {
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        let ctx = &cc.egui_ctx;
-
-        crate::ui::styles::init_styles(ctx);
-
+        crate::ui::styles::init_styles(&cc.egui_ctx);
         Self::default()
     }
 
     fn handle_dropped_files(&mut self, ctx: &egui::Context) {
         let dropped_files = ctx.input(|i| i.raw.dropped_files.clone());
 
-        if !dropped_files.is_empty()
-            && let Some(dropped_file) = dropped_files.first()
-            && let Some(path) = &dropped_file.path
-        {
+        if let Some(path) = dropped_files.first().and_then(|file| file.path.as_ref()) {
             _ = self
                 .state
                 .app_state_request_sender
@@ -60,53 +44,44 @@ impl QualetizeApp {
     }
 
     fn load_image_file(&mut self, path: String, ctx: &egui::Context) {
-        // Cancel any existing processing
-        if self.image_processor.is_processing() {
-            self.image_processor.cancel_current_processing();
-            self.image_processor = ImageProcessor::new();
-        }
-        self.image_processor.cancel_tile_reduce();
-        self.state.tile_reduce_processing = false;
+        self.image_processor.cancel_all();
+        self.state.reset_all_images();
 
         match ImageData::load(&path, ctx) {
             Ok(image_data) => {
-                self.state.reset_all_images();
                 self.state.input_path = Some(path);
                 self.state.input_image = Some(image_data);
-
                 self.state.zoom = 1.0;
                 self.state.pan_offset = egui::Vec2::ZERO;
             }
-            Err(e) => {
-                log::error!("File load Error {e}");
-                self.state.reset_all_images();
-            }
+            Err(e) => log::error!("File load Error {e}"),
         }
     }
 
+    /// Start the pending quantization once the debounce delay has passed and
+    /// the previous run is done. Tile reduction is requested again by
+    /// [`Self::check_qualetize_completion`] once the new base image exists.
     fn handle_settings_changes(&mut self) {
         let Some(color_corrected_image) = &self.state.color_corrected_image else {
             return;
         };
-        // debounce functionality: start preview generation after a certain delay from settings change
         let Some(request) = &self.state.request_update_qualetized_image else {
             return;
         };
-        if request.time.elapsed() < self.state.debounce_delay {
-            return;
-        }
-        if self.image_processor.is_processing() {
+        if request.time.elapsed() < self.state.debounce_delay
+            || self.image_processor.is_qualetizing()
+        {
             return;
         }
 
         self.state.request_update_qualetized_image = None;
         self.image_processor.cancel_tile_reduce();
-        self.state.tile_reduce_processing = false;
-        self.image_processor
-            .start_qualetize(color_corrected_image, self.state.settings.clone());
-
-        // request tile reduce after qualetize finishes
-        self.state.request_update_tile_reduce = self.state.settings.tile_reduce_post_enabled;
+        self.image_processor.start_qualetize(
+            &color_corrected_image.rgba_data,
+            color_corrected_image.width,
+            color_corrected_image.height,
+            self.state.settings.clone(),
+        );
     }
 
     /// Extend the input image so both sides are a multiple of the tile size,
@@ -152,132 +127,11 @@ impl QualetizeApp {
         true
     }
 
-    fn update_color_corrected_image(&mut self, ctx: &egui::Context) {
-        if self.state.color_correction_changed() {
-            self.apply_color_correct_image(ctx);
-            self.state.request_update_qualetized_image = Some(QualetizeRequest {
-                time: std::time::Instant::now(),
-            });
-            self.state.update_color_correction_tracking();
-        }
-    }
-
-    fn check_preview_completion(&mut self, ctx: &egui::Context) {
-        if let Some(result) = self.image_processor.check_preview_complete(ctx) {
-            match result {
-                Ok(image_data) => {
-                    self.state.base_output_image = Some(image_data.clone());
-                    self.state.base_tile_count = Self::count_tiles(
-                        &image_data,
-                        self.state.settings.tile_width,
-                        self.state.settings.tile_height,
-                        self.state.tile_count.options(),
-                    );
-                    if !self.state.settings.tile_reduce_post_enabled
-                        || self.state.settings.tile_reduce_post_threshold <= 0.0
-                    {
-                        self.state.output_image = Some(image_data);
-                        self.state.reduced_tile_count = self.state.base_tile_count;
-                        self.state.tile_reduce_processing = false;
-                    } else {
-                        self.state.request_update_tile_reduce = true;
-                        self.handle_tile_reduce_changes(ctx);
-                    }
-                    self.state.invalidate_palette_sort();
-                    self.state.tile_count.reset();
-                }
-                Err(e) => {
-                    log::error!("Failed to generate preview image: {e}");
-                    self.state.reset_qualetize_outputs();
-                    self.state.tile_reduce_processing = false;
-                }
-            }
-        }
-    }
-
-    fn check_tile_reduce_completion(&mut self, ctx: &egui::Context) {
-        if let Some(result) = self.image_processor.check_tile_reduce_complete() {
-            match result {
-                Ok(res) => {
-                    if res.generation_id != self.state.tile_reduce_generation_id {
-                        log::debug!("Ignoring stale tile reduce result");
-                        return;
-                    }
-                    let Some(base) = &self.state.base_output_image else {
-                        return;
-                    };
-                    let Some(base_indexed) = &base.indexed else {
-                        return;
-                    };
-                    let mut pixels = Vec::with_capacity((base.width * base.height * 4) as usize);
-                    for &pixel_index in &res.indexed_pixels {
-                        let palette_index = pixel_index as usize;
-                        if let Some(color) = base_indexed.palettes.get(palette_index) {
-                            pixels.extend_from_slice(&[color.r, color.g, color.b, color.a]);
-                        } else {
-                            pixels.extend_from_slice(&[0, 0, 0, 255]);
-                        }
-                    }
-                    let size = [base.width as usize, base.height as usize];
-                    let color_image = ColorImage::from_rgba_unmultiplied(size, &pixels);
-                    let texture =
-                        ctx.load_texture("output", color_image, egui::TextureOptions::NEAREST);
-
-                    let mut output = base.clone();
-                    output.texture = texture;
-                    output.rgba_data = pixels;
-                    output.indexed = Some(ImageDataIndexed {
-                        palettes_for_ui: base_indexed.palettes_for_ui.clone(),
-                        palettes: base_indexed.palettes.clone(),
-                        indexed_pixels: res.indexed_pixels,
-                    });
-                    self.state.output_image = Some(output);
-                    self.state.invalidate_palette_sort();
-                    self.state.reduced_tile_count = Self::count_tiles(
-                        self.state.output_image.as_ref().unwrap(),
-                        self.state.settings.tile_width,
-                        self.state.settings.tile_height,
-                        self.state.tile_count.options(),
-                    );
-                    self.state.tile_reduce_processing = false;
-                    let diff = self
-                        .state
-                        .base_tile_count
-                        .and_then(|base| {
-                            self.state
-                                .reduced_tile_count
-                                .map(|reduced| base.saturating_sub(reduced))
-                        })
-                        .unwrap_or(res.merged);
-                    self.state.tile_reduce_toast =
-                        Some(Toast::new(format!("Reduced {diff} tiles")));
-                    self.state.tile_count.mark_dirty();
-                    log::info!("Tile reduce completed: merged {}", res.merged);
-                }
-                Err(e) => {
-                    log::error!("Tile reduce failed: {e}");
-                    self.state.tile_reduce_processing = false;
-                }
-            }
-        }
-    }
-    fn apply_theme(&self, ctx: &egui::Context) {
-        let visuals = match self.state.preferences.appearance_mode {
-            AppearanceMode::Dark => egui::Visuals::dark(),
-            AppearanceMode::Light => egui::Visuals::light(),
-            AppearanceMode::System => match ctx.system_theme() {
-                Some(egui::Theme::Dark) => egui::Visuals::dark(),
-                Some(egui::Theme::Light) => egui::Visuals::light(),
-                None => egui::Visuals::dark(),
-            },
-        };
-        if ctx.global_style().visuals != visuals {
-            ctx.set_visuals(visuals);
-        }
-    }
-
-    fn apply_color_correct_image(&mut self, ctx: &egui::Context) {
+    /// Rebuild the color corrected image from the current pipeline input and
+    /// queue a re-quantization of it.
+    fn refresh_color_corrected_image(&mut self, ctx: &egui::Context) {
         let Some(image) = self.state.processing_input() else {
+            self.state.color_corrected_image = None;
             return;
         };
 
@@ -288,71 +142,145 @@ impl QualetizeApp {
         } else {
             image.clone()
         });
+        self.state.update_color_correction_tracking();
+        self.state.request_qualetize();
     }
 
+    fn check_qualetize_completion(&mut self, ctx: &egui::Context) {
+        let Some(result) = self.image_processor.poll_qualetize() else {
+            return;
+        };
+        match result {
+            Ok(res) => {
+                let indexed = ImageDataIndexed::new(
+                    res.palette_data,
+                    res.colors_per_palette,
+                    res.indexed_data,
+                );
+                let image = ImageData::from_indexed(indexed, res.width, res.height, ctx);
+                self.state.base_output_image = Some(image);
+                // Shows the base image right away and starts the reduction
+                // pass on it when that is enabled.
+                self.state.request_update_tile_reduce = true;
+            }
+            Err(e) => {
+                log::error!("Failed to generate preview image: {e}");
+                self.state.reset_qualetize_outputs();
+            }
+        }
+    }
+
+    fn check_tile_reduce_completion(&mut self, ctx: &egui::Context) {
+        let Some(res) = self.image_processor.poll_tile_reduce() else {
+            return;
+        };
+        let Some(base_indexed) = self
+            .state
+            .base_output_image
+            .as_ref()
+            .and_then(|base| base.indexed.as_ref())
+        else {
+            return;
+        };
+        let base = self.state.base_output_image.as_ref().unwrap();
+
+        let indexed = ImageDataIndexed::new(
+            base_indexed.palettes.clone(),
+            base_indexed.colors_per_palette(),
+            res.indexed_pixels,
+        );
+        let output = ImageData::from_indexed(indexed, base.width, base.height, ctx);
+        self.state.output_image = Some(output);
+        self.state.invalidate_palette_sort();
+        self.state.tile_count.mark_dirty();
+        self.update_tile_counts();
+
+        let diff = match (self.state.base_tile_count, self.state.reduced_tile_count) {
+            (Some(base), Some(reduced)) => base.saturating_sub(reduced),
+            _ => res.merged,
+        };
+        self.state.tile_reduce_toast = Some(Toast::new(format!("Reduced {diff} tiles")));
+        log::info!("Tile reduce completed: merged {}", res.merged);
+    }
+
+    fn apply_theme(&self, ctx: &egui::Context) {
+        let visuals = match self.state.preferences.appearance_mode {
+            AppearanceMode::Dark => egui::Visuals::dark(),
+            AppearanceMode::Light => egui::Visuals::light(),
+            AppearanceMode::System => match ctx.system_theme() {
+                Some(egui::Theme::Light) => egui::Visuals::light(),
+                _ => egui::Visuals::dark(),
+            },
+        };
+        if ctx.global_style().visuals != visuals {
+            ctx.set_visuals(visuals);
+        }
+    }
+
+    /// Show the base image and, when enabled, start the tile reduction pass on it.
     fn handle_tile_reduce_changes(&mut self, ctx: &egui::Context) {
         if !self.state.request_update_tile_reduce {
             return;
         }
         self.state.request_update_tile_reduce = false;
+        self.image_processor.cancel_tile_reduce();
 
         let Some(base) = &self.state.base_output_image else {
             return;
         };
-
-        // Snapshot everything the worker needs before mutating state below.
-        let base_image = base.clone();
         let reduce_input = base
             .indexed
             .as_ref()
             .map(|indexed| (indexed.indexed_pixels.clone(), indexed.palettes.clone()));
-        let (base_width, base_height) = (base.width, base.height);
+        let (width, height) = (base.width, base.height);
 
-        self.state.output_image = Some(base_image);
+        self.state.output_image = Some(base.clone());
         self.state.invalidate_palette_sort();
-        self.state.reduced_tile_count = self.state.base_tile_count;
         self.state.tile_count.mark_dirty();
-        if !self.state.settings.tile_reduce_post_enabled
-            || self.state.settings.tile_reduce_post_threshold <= 0.0
-        {
-            self.state.tile_reduce_processing = false;
+
+        let settings = &self.state.settings;
+        if !settings.tile_reduce_post_enabled || settings.tile_reduce_post_threshold <= 0.0 {
             return;
         }
-
         let Some((indexed_pixels, palettes)) = reduce_input else {
-            self.state.tile_reduce_processing = false;
             return;
         };
 
-        let opts = crate::image_processor::TileReduceOptions {
-            tile_width: self.state.settings.tile_width,
-            tile_height: self.state.settings.tile_height,
-            threshold: self.state.settings.tile_reduce_post_threshold,
-            allow_flip_x: self.state.settings.tile_reduce_allow_flip_x,
-            allow_flip_y: self.state.settings.tile_reduce_allow_flip_y,
-            use_blur: true,
+        let opts = TileReduceOptions {
+            tile_width: settings.tile_width,
+            tile_height: settings.tile_height,
+            threshold: settings.tile_reduce_post_threshold,
+            allow_flip_x: settings.tile_reduce_allow_flip_x,
+            allow_flip_y: settings.tile_reduce_allow_flip_y,
         };
-
-        let generation_id = self.image_processor.start_tile_reduce(
-            indexed_pixels,
-            palettes,
-            base_width,
-            base_height,
-            opts,
-        );
-        self.state.tile_reduce_generation_id = generation_id;
-        self.state.tile_reduce_processing = true;
+        self.image_processor
+            .start_tile_reduce(indexed_pixels, palettes, width, height, opts);
         ctx.request_repaint();
     }
 
-    fn count_tiles(
-        image: &ImageData,
-        tile_w: u16,
-        tile_h: u16,
-        options: TileCountOptions,
-    ) -> Option<usize> {
-        let indexed = image.indexed.as_ref()?;
-        ImageData::count_unique_tiles(indexed, image.width, image.height, tile_w, tile_h, options)
+    /// Recount the unique tiles of both output images once something they
+    /// depend on changed: the images themselves or the counting options.
+    /// Both numbers are derived here, in one place, so the footer count and
+    /// the "Reduced N tiles" label can never disagree about the options.
+    fn update_tile_counts(&mut self) {
+        if !self.state.tile_count.dirty {
+            return;
+        }
+        self.state.tile_count.dirty = false;
+
+        let count = |image: &Option<ImageData>| {
+            let image = image.as_ref()?;
+            ImageData::count_unique_tiles(
+                image.indexed.as_ref()?,
+                image.width,
+                image.height,
+                self.state.settings.tile_width,
+                self.state.settings.tile_height,
+                self.state.tile_count.options(),
+            )
+        };
+        self.state.base_tile_count = count(&self.state.base_output_image);
+        self.state.reduced_tile_count = count(&self.state.output_image);
     }
 
     /// Write `source` to `output_path` on a worker thread.
@@ -419,78 +347,40 @@ impl QualetizeApp {
     }
 
     fn handle_requests(&mut self, ctx: &egui::Context) {
-        // Check for file dialog results first
-        let Ok(app_state_request) = &self.state.app_state_request_receiver.try_recv() else {
+        let Ok(request) = self.state.app_state_request_receiver.try_recv() else {
             return;
         };
-        match app_state_request {
+        match request {
             AppStateRequest::LoadImage { path } => {
-                self.load_image_file(path.clone(), ctx);
+                self.load_image_file(path, ctx);
                 self.update_tile_fit(ctx);
-                self.apply_color_correct_image(ctx);
-                self.state.request_update_qualetized_image = Some(QualetizeRequest {
-                    time: std::time::Instant::now(),
-                });
-                self.state.update_color_correction_tracking();
+                self.refresh_color_corrected_image(ctx);
             }
             AppStateRequest::ExportImage {
                 source,
                 format,
                 output_path,
             } => {
-                self.export_image(*source, *format, output_path.clone());
+                self.export_image(source, format, output_path);
             }
             AppStateRequest::SaveSettings { path } => {
-                let settings_bundle = SettingsBundle::new(
-                    self.state.settings.clone(),
-                    self.state.color_correction.clone(),
-                    self.state.palette_sort_settings,
-                );
-
-                match settings_bundle.save_to_file(path) {
-                    Ok(()) => {
-                        log::info!("Settings saved successfully to: {path}");
-                    }
-                    Err(e) => {
-                        log::error!("Failed to save settings: {e}");
-                    }
+                match self.state.settings_bundle().save_to_file(&path) {
+                    Ok(()) => log::info!("Settings saved successfully to: {path}"),
+                    Err(e) => log::error!("Failed to save settings: {e}"),
                 }
             }
-            AppStateRequest::LoadSettings { path } => {
-                match SettingsBundle::load_from_file(path) {
-                    Ok(settings_bundle) => {
-                        // Cancel any existing processing
-                        if self.image_processor.is_processing() {
-                            self.image_processor.cancel_current_processing();
-                            self.image_processor = ImageProcessor::new();
-                        }
-
-                        // Apply loaded settings
-                        self.state.settings = settings_bundle.qualetize_settings;
-                        self.state.color_correction = settings_bundle.color_correction;
-                        self.state.palette_sort_settings = settings_bundle.sort_settings;
-
-                        self.state.request_update_qualetized_image = Some(QualetizeRequest {
-                            time: std::time::Instant::now(),
-                        });
-
-                        if self.state.input_image.is_some() {
-                            self.update_tile_fit(ctx);
-                            self.apply_color_correct_image(ctx);
-                        } else {
-                            self.state.color_corrected_image = None;
-                        }
-
-                        // Update tracking
-                        self.state.update_color_correction_tracking();
-
-                        log::info!("Settings loaded successfully from: {path}");
-                    }
-                    Err(e) => {
-                        log::error!("Failed to load settings: {e}");
-                    }
+            AppStateRequest::LoadSettings { path } => match SettingsBundle::load_from_file(&path) {
+                Ok(bundle) => {
+                    self.image_processor.cancel_all();
+                    self.state.settings = bundle.qualetize_settings;
+                    self.state.color_correction = bundle.color_correction;
+                    self.state.palette_sort_settings = bundle.sort_settings;
+                    self.update_tile_fit(ctx);
+                    self.refresh_color_corrected_image(ctx);
+                    log::info!("Settings loaded successfully from: {path}");
                 }
-            }
+                Err(e) => log::error!("Failed to load settings: {e}"),
+            },
             AppStateRequest::OpenImageDialog => {
                 self.spawn_file_dialog(|dialog| {
                     let path = dialog
@@ -505,7 +395,6 @@ impl QualetizeApp {
                 let Some(input_path) = self.state.input_path.clone() else {
                     return;
                 };
-                let (source, format) = (*source, *format);
                 let default_path =
                     get_export_path(&input_path, &format, Some(source.file_suffix()));
 
@@ -562,24 +451,20 @@ impl QualetizeApp {
         }
 
         let col0_is_clear = self.state.settings.col0_is_clear;
-        let sorted = self
+        self.state.output_palette_sorted_indexed_image = self
             .state
             .output_image
             .as_ref()
             .and_then(|image| image.indexed.as_ref())
             .map(|indexed| indexed.sorted(settings.mode, settings.order, col0_is_clear));
-
-        self.state.output_palette_sorted_indexed_image = sorted;
     }
 }
 
 impl Drop for QualetizeApp {
     fn drop(&mut self) {
-        // Cancel any ongoing processing
-        self.image_processor.cancel_current_processing();
+        self.image_processor.cancel_all();
         // Flush a change made in the last moments before quitting
         self.state.save_session_now();
-        log::debug!("QualetizeApp dropped, resources cleaned up");
     }
 }
 
@@ -587,11 +472,7 @@ impl eframe::App for QualetizeApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
-        // The Qualetized and Tile Reduced panels show their own spinners, so the
-        // two stages are tracked separately (`state.tile_reduce_processing`).
-        let qualetize_processing = self.image_processor.is_processing();
 
-        // apply theme
         self.apply_theme(ctx);
 
         // Handle drag and drop first
@@ -599,19 +480,13 @@ impl eframe::App for QualetizeApp {
             self.handle_dropped_files(ctx);
         }
 
-        // Check preview completion
-        self.check_preview_completion(ctx);
-        // Check tile reduce completion
+        self.check_qualetize_completion(ctx);
         self.check_tile_reduce_completion(ctx);
 
         // Re-extend if the tile size changed, then update the corrected image
-        if self.update_tile_fit(ctx) {
-            self.apply_color_correct_image(ctx);
-            self.state.request_update_qualetized_image = Some(QualetizeRequest {
-                time: std::time::Instant::now(),
-            });
+        if self.update_tile_fit(ctx) || self.state.color_correction_changed() {
+            self.refresh_color_corrected_image(ctx);
         }
-        self.update_color_corrected_image(ctx);
 
         // Handle settings changes after checking completion
         self.handle_settings_changes();
@@ -620,13 +495,17 @@ impl eframe::App for QualetizeApp {
         self.handle_tile_reduce_changes(ctx);
 
         self.update_palette_sort_settings();
+        self.update_tile_counts();
 
-        // Handle export requests
         self.handle_requests(ctx);
 
         // Mirror preferences and settings to disk so they survive a restart
         self.state.check_and_save_preferences();
         self.state.check_and_save_session(ctx);
+
+        // The Qualetized and Tile Reduced panels show their own spinners.
+        let qualetize_processing = self.image_processor.is_qualetizing();
+        self.state.tile_reduce_processing = self.image_processor.is_tile_reducing();
 
         let mut settings_changed = false;
         let mut tile_reduce_changed = false;
@@ -684,16 +563,14 @@ impl eframe::App for QualetizeApp {
             });
 
         if settings_changed {
-            self.state.request_update_qualetized_image = Some(QualetizeRequest {
-                time: std::time::Instant::now(),
-            });
+            self.state.request_qualetize();
         }
         if tile_reduce_changed {
             self.state.request_update_tile_reduce = true;
         }
 
-        // Repaint drawing while updating image
-        if self.image_processor.is_processing()
+        // Keep repainting while work is pending or in flight
+        if qualetize_processing
             || self.state.tile_reduce_processing
             || self.state.request_update_qualetized_image.is_some()
             || self.state.request_update_tile_reduce

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -168,7 +168,9 @@ pub fn display_value_to_gamma(display: f32) -> f32 {
 }
 
 pub fn format_percentage(value: f32) -> String {
-    format!("{:+.0}%", value * 100.0)
+    // `+ 0.0` turns a negative zero into a positive one, so a slider dragged
+    // back to the middle reads "+0%" rather than "-0%".
+    format!("{:+.0}%", (value * 100.0).round() + 0.0)
 }
 
 pub fn format_gamma(gamma: f32) -> String {
@@ -254,6 +256,14 @@ mod tests {
             assert!((g - g2).abs() < 1e-5, "{g} vs {g2}");
             assert!((b - b2).abs() < 1e-5, "{b} vs {b2}");
         }
+    }
+
+    #[test]
+    fn percentages_never_show_a_negative_zero() {
+        assert_eq!(format_percentage(-0.0), "+0%");
+        assert_eq!(format_percentage(-0.004), "+0%");
+        assert_eq!(format_percentage(-0.43), "-43%");
+        assert_eq!(format_percentage(0.43), "+43%");
     }
 
     #[test]

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -13,14 +13,10 @@ impl ColorProcessor {
         let tone_curve = Self::tone_curve(corrections);
         let mut output: RgbaImage = ImageBuffer::new(width, height);
 
-        // chunks_exact and pixels_mut walk the buffers in the same row-major
-        // order, so no per-pixel coordinate arithmetic is needed.
-        for (source, target) in pixels.chunks_exact(4).zip(output.pixels_mut()) {
-            *target = Self::apply_pixel_corrections(
-                &Rgba([source[0], source[1], source[2], source[3]]),
-                corrections,
-                &tone_curve,
-            );
+        // Both sides walk the buffers in the same row-major order, so no
+        // per-pixel coordinate arithmetic is needed.
+        for (source, target) in pixels.as_chunks::<4>().0.iter().zip(output.pixels_mut()) {
+            *target = Self::apply_pixel_corrections(&Rgba(*source), corrections, &tone_curve);
         }
 
         output

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -49,6 +49,14 @@ pub fn save_indexed_bmp(
     width: u32,
     height: u32,
 ) -> Result<(), String> {
+    if indexed_pixel_data.len() != (width * height) as usize {
+        return Err(format!(
+            "indexed data has {} pixels, expected {}x{}",
+            indexed_pixel_data.len(),
+            width,
+            height
+        ));
+    }
     // Create 8-bit indexed BMP with palette (always 256 entries)
     let palette_size = palette_data.len().min(256); // Max 256 colors for 8-bit
     let row_size = width.div_ceil(4) * 4; // 4-byte aligned for 8-bit data
@@ -91,18 +99,10 @@ pub fn save_indexed_bmp(
         bmp_data.extend_from_slice(&[0, 0, 0, 0]);
     }
 
-    // Image data (bottom-up, 8-bit indexed)
-    for y in (0..height).rev() {
-        for x in 0..width {
-            let pixel_idx = (y * width + x) as usize;
-            if pixel_idx < indexed_pixel_data.len() {
-                bmp_data.push(indexed_pixel_data[pixel_idx]);
-            } else {
-                bmp_data.push(0);
-            }
-        }
-        // Add padding if necessary
-        let padding = (row_size - width) as usize;
+    // Image data (bottom-up, 8-bit indexed), each row padded to 4 bytes
+    let padding = (row_size - width) as usize;
+    for row in indexed_pixel_data.chunks_exact(width as usize).rev() {
+        bmp_data.extend_from_slice(row);
         bmp_data.extend(std::iter::repeat_n(0, padding));
     }
 
@@ -125,25 +125,56 @@ pub fn save_rgba_image(
 
     let dynamic_img = image::DynamicImage::ImageRgba8(img_buffer);
 
-    match export_format {
+    let format = match export_format {
+        crate::types::ExportFormat::Png => image::ImageFormat::Png,
+        crate::types::ExportFormat::Bmp => image::ImageFormat::Bmp,
         crate::types::ExportFormat::PngIndexed => {
-            return Err(
-                "Indexed PNG format requires palette data, use ExportableImageData::Indexed"
-                    .to_string(),
-            );
+            return Err("indexed PNG needs palette data, use save_indexed_png".to_string());
         }
-        crate::types::ExportFormat::Png => {
-            dynamic_img
-                .save_with_format(output_path, image::ImageFormat::Png)
-                .map_err(|e| format!("PNG save error: {e}"))?;
-        }
-        crate::types::ExportFormat::Bmp => {
-            dynamic_img
-                .save_with_format(output_path, image::ImageFormat::Bmp)
-                .map_err(|e| format!("BMP save error: {e}"))?;
+    };
+    dynamic_img
+        .save_with_format(output_path, format)
+        .map_err(|e| format!("{format:?} save error: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gray(v: u8) -> BGRA8 {
+        BGRA8 {
+            b: v,
+            g: v,
+            r: v,
+            a: 255,
         }
     }
 
-    log::info!("RGBA image exported successfully to: {output_path}");
-    Ok(())
+    /// Rows are stored bottom-up and padded to a multiple of four bytes, which
+    /// is where a hand-rolled BMP writer usually goes wrong.
+    #[test]
+    fn bmp_rows_are_bottom_up_and_padded() {
+        let dir = std::env::temp_dir().join(format!("qualetize_gui_bmp_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.bmp");
+
+        // 3x2 image: top row 1,2,3 / bottom row 4,5,6
+        let pixels = [1, 2, 3, 4, 5, 6];
+        save_indexed_bmp(path.to_str().unwrap(), &pixels, &[gray(0), gray(10)], 3, 2).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        let data_offset = 54 + 256 * 4;
+        assert_eq!(bytes.len(), data_offset + 2 * 4);
+        assert_eq!(&bytes[data_offset..data_offset + 4], &[4, 5, 6, 0]);
+        assert_eq!(&bytes[data_offset + 4..], &[1, 2, 3, 0]);
+        // second palette entry, BGRA
+        assert_eq!(&bytes[54 + 4..54 + 8], &[10, 10, 10, 255]);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn bmp_rejects_a_pixel_buffer_of_the_wrong_size() {
+        assert!(save_indexed_bmp("unused.bmp", &[0; 5], &[gray(0)], 3, 2).is_err());
+    }
 }

--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -1,41 +1,85 @@
 use crate::types::qualetize::{Qualetize, QualetizePlanOwned, Vec4f};
-use crate::types::{BGRA8, ImageData, QualetizeSettings};
-use egui::Context;
-use std::sync::mpsc;
+use crate::types::{BGRA8, QualetizeSettings};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
 
 #[derive(Debug)]
 pub struct QualetizeResult {
     pub indexed_data: Vec<u8>,
     pub palette_data: Vec<BGRA8>,
-    pub settings: QualetizeSettings,
+    pub colors_per_palette: usize,
     pub width: u32,
     pub height: u32,
-    pub generation_id: u64,
+}
+
+/// One background computation whose result is polled from the UI thread.
+///
+/// Starting a job replaces the receiver, so a result from an earlier thread
+/// can never be observed: its send fails against the dropped receiver and the
+/// thread simply exits. No generation counter or join bookkeeping is needed.
+struct Job<T> {
+    receiver: Option<mpsc::Receiver<T>>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl<T> Default for Job<T> {
+    fn default() -> Self {
+        Self {
+            receiver: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl<T: Send + 'static> Job<T> {
+    /// Cancel the running job, if any, and run `work` on a new thread.
+    /// `work` returns `None` when it stopped early because of the cancel flag.
+    fn start(&mut self, work: impl FnOnce(&AtomicBool) -> Option<T> + Send + 'static) {
+        self.cancel();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = mpsc::channel();
+        let flag = cancel.clone();
+        std::thread::spawn(move || {
+            if let Some(result) = work(&flag) {
+                let _ = sender.send(result);
+            }
+        });
+        self.receiver = Some(receiver);
+        self.cancel = cancel;
+    }
+
+    /// Ask the worker to stop and forget about its result.
+    fn cancel(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        self.receiver = None;
+    }
+
+    fn is_running(&self) -> bool {
+        self.receiver.is_some()
+    }
+
+    /// The finished result, once. A worker that exited without one (cancelled
+    /// or panicked) just ends the job.
+    fn poll(&mut self) -> Option<T> {
+        let receiver = self.receiver.as_ref()?;
+        match receiver.try_recv() {
+            Ok(result) => {
+                self.receiver = None;
+                Some(result)
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.receiver = None;
+                None
+            }
+            Err(mpsc::TryRecvError::Empty) => None,
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct ImageProcessor {
-    preview_thread: Option<std::thread::JoinHandle<()>>,
-    preview_receiver: Option<mpsc::Receiver<Result<QualetizeResult, String>>>,
-    cancel_sender: Option<mpsc::Sender<()>>,
-    current_generation_id: u64,
-    active_threads: Vec<std::thread::JoinHandle<()>>,
-    tile_reduce_thread: Option<std::thread::JoinHandle<()>>,
-    tile_reduce_receiver: Option<mpsc::Receiver<Result<TileReduceResult, String>>>,
-    tile_reduce_generation_id: u64,
-    tile_reduce_cancel: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-}
-
-struct ClusterMember {
-    indices: Vec<u8>,
-    blurred_colors: Vec<[u8; 4]>,
-}
-
-struct ClusterRep {
-    indices: Vec<u8>,
-    blurred_colors: Vec<[u8; 4]>,
-    members: Vec<ClusterMember>,
-    insert_cursor: usize,
+    qualetize: Job<Result<QualetizeResult, String>>,
+    tile_reduce: Job<TileReduceResult>,
 }
 
 pub struct TileReduceOptions {
@@ -44,126 +88,43 @@ pub struct TileReduceOptions {
     pub threshold: f32,
     pub allow_flip_x: bool,
     pub allow_flip_y: bool,
-    pub use_blur: bool,
 }
 
 pub struct TileReduceResult {
     pub indexed_pixels: Vec<u8>,
     pub merged: usize,
-    pub generation_id: u64,
 }
 
 impl ImageProcessor {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn start_qualetize(
         &mut self,
-        color_corrected_image: &ImageData,
+        rgba_data: &[u8],
+        width: u32,
+        height: u32,
         settings: QualetizeSettings,
     ) {
-        // Cancel any existing processing
-        self.cancel_current_processing();
-
         // Convert up front so the worker thread starts on data it can use directly.
-        let bgra_data = to_bgra(&color_corrected_image.rgba_data);
-        let width = color_corrected_image.width;
-        let height = color_corrected_image.height;
-
-        let (result_sender, result_receiver) = mpsc::channel();
-        let (cancel_sender, cancel_receiver) = mpsc::channel();
-        let generation_id = self.current_generation_id;
-
-        self.preview_receiver = Some(result_receiver);
-        self.cancel_sender = Some(cancel_sender);
-
-        let thread = std::thread::spawn(move || {
-            let result = Self::generate_preview(
-                bgra_data,
-                width,
-                height,
-                settings,
-                cancel_receiver,
-                generation_id,
-            );
-            let _ = result_sender.send(result);
+        let bgra_data = to_bgra(rgba_data);
+        self.qualetize.start(move |cancel| {
+            // The C call cannot be interrupted, so this only saves work when the
+            // job was superseded before its thread got scheduled.
+            if cancel.load(Ordering::Relaxed) {
+                return None;
+            }
+            Some(run_qualetize(&bgra_data, width, height, &settings))
         });
-        self.preview_thread = Some(thread);
     }
 
-    pub fn check_preview_complete(&mut self, ctx: &Context) -> Option<Result<ImageData, String>> {
-        self.cleanup_finished_threads();
-
-        if let Some(receiver) = &mut self.preview_receiver
-            && let Ok(result) = receiver.try_recv()
-        {
-            self.preview_thread = None;
-            self.preview_receiver = None;
-
-            return match result {
-                Ok(qualetize_result) => {
-                    if qualetize_result.generation_id != self.current_generation_id {
-                        log::debug!(
-                            "Ignoring outdated result from generation {} (current: {})",
-                            qualetize_result.generation_id,
-                            self.current_generation_id
-                        );
-                        return None;
-                    }
-                    log::debug!(
-                        "Accepting result from generation {}",
-                        qualetize_result.generation_id
-                    );
-                    Some(ImageData::create_from_qualetize_result(
-                        qualetize_result,
-                        ctx,
-                    ))
-                }
-                // A cancelled run is not a failure worth reporting.
-                Err(e) if e.contains("Processing cancelled") => None,
-                Err(e) => Some(Err(e)),
-            };
-        }
-        None
+    pub fn poll_qualetize(&mut self) -> Option<Result<QualetizeResult, String>> {
+        self.qualetize.poll()
     }
 
-    pub fn is_processing(&self) -> bool {
-        self.preview_thread.is_some()
+    pub fn is_qualetizing(&self) -> bool {
+        self.qualetize.is_running()
     }
 
-    pub fn cancel_tile_reduce(&mut self) {
-        if let Some(cancel) = &self.tile_reduce_cancel {
-            cancel.store(true, std::sync::atomic::Ordering::Relaxed);
-        }
-        if let Some(old_thread) = self.tile_reduce_thread.take() {
-            self.active_threads.push(old_thread);
-        }
-        self.tile_reduce_receiver = None;
-        self.tile_reduce_cancel = None;
-    }
-
-    pub fn cancel_current_processing(&mut self) {
-        if let Some(cancel_sender) = &self.cancel_sender {
-            let _ = cancel_sender.send(());
-        }
-
-        // Let the old thread run to completion in the background; its result is
-        // discarded because the generation ID below no longer matches.
-        if let Some(old_thread) = self.preview_thread.take() {
-            self.active_threads.push(old_thread);
-        }
-
-        self.preview_thread = None;
-        self.preview_receiver = None;
-        self.cancel_sender = None;
-        self.current_generation_id += 1;
-
-        self.cleanup_finished_threads();
-    }
-
-    fn cleanup_finished_threads(&mut self) {
-        self.active_threads.retain(|thread| !thread.is_finished());
+    pub fn cancel_qualetize(&mut self) {
+        self.qualetize.cancel();
     }
 
     pub fn start_tile_reduce(
@@ -173,451 +134,385 @@ impl ImageProcessor {
         width: u32,
         height: u32,
         opts: TileReduceOptions,
-    ) -> u64 {
-        // cancel previous
-        self.cancel_tile_reduce();
-        let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        self.tile_reduce_cancel = Some(cancel_flag.clone());
-        self.tile_reduce_generation_id = self.tile_reduce_generation_id.wrapping_add(1);
-
-        let (sender, receiver) = mpsc::channel();
-        self.tile_reduce_receiver = Some(receiver);
-
-        let generation_id = self.tile_reduce_generation_id;
-        let thread = std::thread::spawn(move || {
+    ) {
+        self.tile_reduce.start(move |cancel| {
             let mut indexed_pixels = indexed;
-            let merged = Self::reduce_tiles_indexed(
-                &mut indexed_pixels,
-                &palettes,
-                width,
-                height,
-                &opts,
-                Some(cancel_flag),
-            );
-            if merged == usize::MAX {
-                return;
-            }
-            let result = TileReduceResult {
+            let merged =
+                reduce_tiles_indexed(&mut indexed_pixels, &palettes, width, height, &opts, cancel)?;
+            Some(TileReduceResult {
                 indexed_pixels,
                 merged,
-                generation_id,
-            };
-            let _ = sender.send(Ok(result));
+            })
         });
-        self.tile_reduce_thread = Some(thread);
-        generation_id
     }
 
-    pub fn check_tile_reduce_complete(&mut self) -> Option<Result<TileReduceResult, String>> {
-        self.cleanup_finished_threads();
-        if let Some(receiver) = &mut self.tile_reduce_receiver {
-            match receiver.try_recv() {
-                Ok(result) => {
-                    self.tile_reduce_thread = None;
-                    self.tile_reduce_receiver = None;
-                    self.tile_reduce_cancel = None;
-                    return Some(result);
-                }
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.tile_reduce_thread = None;
-                    self.tile_reduce_receiver = None;
-                    self.tile_reduce_cancel = None;
-                    return Some(Err("Tile reduce cancelled".to_string()));
-                }
-                Err(mpsc::TryRecvError::Empty) => {}
-            }
-        }
-        None
+    pub fn poll_tile_reduce(&mut self) -> Option<TileReduceResult> {
+        self.tile_reduce.poll()
     }
 
-    fn generate_preview(
-        bgra_data: Vec<BGRA8>,
-        width: u32,
-        height: u32,
-        settings: QualetizeSettings,
-        cancel_receiver: mpsc::Receiver<()>,
-        generation_id: u64,
-    ) -> Result<QualetizeResult, String> {
-        log::info!("Starting preview generation from BGRA data (generation {generation_id})");
-
-        // Check for cancellation
-        if cancel_receiver.try_recv().is_ok() {
-            log::info!("Processing cancelled for generation {generation_id}");
-            return Err("Processing cancelled".to_string());
-        }
-
-        // Use the common qualetize processing function
-        let mut qualetize_result =
-            Self::perform_qualetize_processing(bgra_data, width, height, settings)?;
-
-        // Set the generation ID for preview tracking
-        qualetize_result.generation_id = generation_id;
-
-        Ok(qualetize_result)
+    pub fn is_tile_reducing(&self) -> bool {
+        self.tile_reduce.is_running()
     }
 
-    pub fn perform_qualetize_processing(
-        bgra_data: Vec<BGRA8>,
-        width: u32,
-        height: u32,
-        settings: QualetizeSettings,
-    ) -> Result<QualetizeResult, String> {
-        // Create qualetize plan
-        let plan = QualetizePlanOwned::from(settings.clone());
+    pub fn cancel_tile_reduce(&mut self) {
+        self.tile_reduce.cancel();
+    }
 
-        // Prepare output buffers
-        let output_size = (width * height) as usize;
-        let mut output_data: Vec<u8> = vec![0; output_size];
-        let palette_size = (settings.n_palettes * settings.n_colors) as usize;
-        let mut output_palette: Vec<BGRA8> = vec![
-            BGRA8 {
-                b: 0,
-                g: 0,
-                r: 0,
-                a: 0
-            };
-            palette_size
-        ];
-        let mut rmse = Vec4f { f32: [0.0; 4] };
+    pub fn cancel_all(&mut self) {
+        self.cancel_qualetize();
+        self.cancel_tile_reduce();
+    }
+}
 
-        // Call qualetize
-        let result = unsafe {
-            Qualetize(
-                output_data.as_mut_ptr(),
-                output_palette.as_mut_ptr(),
-                bgra_data.as_ptr(),
-                std::ptr::null(),
-                width,
-                height,
-                plan.as_ptr(),
-                &mut rmse,
-            )
+fn run_qualetize(
+    bgra_data: &[BGRA8],
+    width: u32,
+    height: u32,
+    settings: &QualetizeSettings,
+) -> Result<QualetizeResult, String> {
+    let plan = QualetizePlanOwned::from(settings.clone());
+
+    let mut output_data: Vec<u8> = vec![0; (width * height) as usize];
+    // usize arithmetic: the u16 product would wrap for out-of-range settings
+    // and let the library write past the end of the buffer.
+    let palette_size = settings.n_palettes as usize * settings.n_colors as usize;
+    let mut output_palette: Vec<BGRA8> = vec![
+        BGRA8 {
+            b: 0,
+            g: 0,
+            r: 0,
+            a: 0
         };
+        palette_size
+    ];
+    let mut rmse = Vec4f { f32: [0.0; 4] };
 
-        if result == 0 {
-            return Err("Qualetize processing failed".to_string());
-        }
-
-        log::debug!("Qualetize succeeded, RMSE: {:?}", rmse.f32);
-
-        Ok(QualetizeResult {
-            indexed_data: output_data,
-            palette_data: output_palette,
-            settings,
+    // SAFETY: every buffer is sized as the plan describes (width*height
+    // indices, n_palettes*n_colors palette entries), `plan` owns the custom
+    // level arrays it points to for the duration of the call, and the
+    // library does not retain any of the pointers.
+    let result = unsafe {
+        Qualetize(
+            output_data.as_mut_ptr(),
+            output_palette.as_mut_ptr(),
+            bgra_data.as_ptr(),
+            std::ptr::null(),
             width,
             height,
-            generation_id: 0, // Not needed for export
-        })
+            plan.as_ptr(),
+            &mut rmse,
+        )
+    };
+
+    if result == 0 {
+        return Err("Qualetize processing failed".to_string());
     }
 
-    pub fn reduce_tiles_indexed(
-        indexed: &mut [u8],
-        palette: &[BGRA8],
-        width: u32,
-        height: u32,
-        opts: &TileReduceOptions,
-        cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    ) -> usize {
-        // Quality/speed tuning
-        let medoid_recompute_interval = 8;
-        let max_members_tracked = 64;
+    log::debug!("Qualetize succeeded, RMSE: {:?}", rmse.f32);
 
-        if opts.tile_width == 0
-            || opts.tile_height == 0
-            || !width.is_multiple_of(opts.tile_width as u32)
-            || !height.is_multiple_of(opts.tile_height as u32)
-        {
-            log::warn!("Tile reduce post-process skipped due to incompatible dimensions");
-            return 0;
-        }
+    Ok(QualetizeResult {
+        indexed_data: output_data,
+        palette_data: output_palette,
+        colors_per_palette: settings.n_colors as usize,
+        width,
+        height,
+    })
+}
 
-        let tiles_x = width / opts.tile_width as u32;
-        let tiles_y = height / opts.tile_height as u32;
-        let tile_w = opts.tile_width as usize;
-        let tile_h = opts.tile_height as usize;
-        let tile_area = tile_w * tile_h;
-        let stride = width as usize;
-        let orientation_maps =
-            Orientation::maps(tile_w, tile_h, opts.allow_flip_x, opts.allow_flip_y);
+/// One tile as the reducer sees it: its palette indices, and the blurred
+/// colors those indices resolve to, which is what tiles are compared on.
+#[derive(Clone)]
+struct Tile {
+    indices: Vec<u8>,
+    blurred_colors: Vec<[u8; 4]>,
+}
 
-        let mut tile_indices_buf = vec![0u8; tile_area];
-        let mut tile_colors_buf = vec![[0u8; 4]; tile_area];
-        let mut tile_blur_buf = vec![[0u8; 4]; tile_area];
+struct Cluster {
+    /// The tile written in place of every member.
+    rep: Tile,
+    /// Recent members, kept so the representative can be re-chosen as the
+    /// medoid of what actually joined the cluster.
+    members: Vec<Tile>,
+    insert_cursor: usize,
+}
 
-        let mut representatives: Vec<ClusterRep> = Vec::new();
-        let mut merged = 0usize;
-        let mut oriented_tiles: Vec<Vec<[u8; 4]>> = Vec::with_capacity(orientation_maps.len());
+/// Merge tiles whose blurred colors are within `opts.threshold` MSE of an
+/// earlier tile (in any allowed flip), rewriting `indexed` in place.
+///
+/// Returns the number of tiles replaced, or `None` when `cancel` was raised.
+pub fn reduce_tiles_indexed(
+    indexed: &mut [u8],
+    palette: &[BGRA8],
+    width: u32,
+    height: u32,
+    opts: &TileReduceOptions,
+    cancel: &AtomicBool,
+) -> Option<usize> {
+    // Quality/speed tuning
+    const MEDOID_RECOMPUTE_INTERVAL: usize = 8;
+    const MAX_MEMBERS_TRACKED: usize = 64;
 
-        let mut coords: Vec<(u32, u32, f32)> = Vec::with_capacity((tiles_x * tiles_y) as usize);
-        let center_x = tiles_x as f32 / 2.0;
-        let center_y = tiles_y as f32 / 2.0;
-        for ty in 0..tiles_y {
-            for tx in 0..tiles_x {
-                let cx = tx as f32 + 0.5;
-                let cy = ty as f32 + 0.5;
-                let dist2 = (cx - center_x).powi(2) + (cy - center_y).powi(2);
-                coords.push((tx, ty, dist2));
-            }
-        }
-        coords.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
-
-        for (tx, ty, _) in coords {
-            if let Some(flag) = &cancel_flag
-                && flag.load(std::sync::atomic::Ordering::Relaxed)
-            {
-                return usize::MAX;
-            }
-            let tile_indices = &mut tile_indices_buf;
-            for y in 0..tile_h {
-                let offset = ((ty as usize * tile_h + y) * stride) + (tx as usize * tile_w);
-                tile_indices[y * tile_w..(y + 1) * tile_w]
-                    .copy_from_slice(&indexed[offset..offset + tile_w]);
-            }
-
-            Self::expand_indices_to_colors_into(tile_indices, palette, &mut tile_colors_buf);
-            if opts.use_blur {
-                Self::blur_tile_colors_into(&tile_colors_buf, &mut tile_blur_buf, tile_w, tile_h);
-            } else {
-                tile_blur_buf.copy_from_slice(&tile_colors_buf);
-            }
-
-            oriented_tiles.clear();
-            for map in &orientation_maps {
-                let oriented = Self::orient_tile_to_rep(&tile_blur_buf, &map.map);
-                oriented_tiles.push(oriented);
-            }
-
-            let mut matched: Option<(usize, Orientation)> = None;
-            for (idx, rep) in representatives.iter().enumerate() {
-                let (best_mse, best_orient) = Self::best_orientation_mse_preoriented(
-                    &rep.blurred_colors,
-                    &oriented_tiles,
-                    &orientation_maps,
-                );
-                if best_mse <= opts.threshold {
-                    matched = Some((idx, best_orient));
-                    break;
-                }
-            }
-
-            if let Some((rep_idx, orientation)) = matched {
-                let rep = &representatives[rep_idx];
-                let map = orientation_maps
-                    .iter()
-                    .find(|m| m.orientation == orientation)
-                    .map(|m| &m.map)
-                    .unwrap_or(&orientation_maps[0].map);
-                for y in 0..tile_h {
-                    let offset = ((ty as usize * tile_h + y) * stride) + (tx as usize * tile_w);
-                    Self::write_rep_with_orientation(
-                        &mut indexed[offset..offset + tile_w],
-                        &rep.indices,
-                        tile_w,
-                        tile_h,
-                        y,
-                        map,
-                    );
-                }
-                // add member and update representative by medoid
-                if let Some(rep) = representatives.get_mut(rep_idx) {
-                    let member = ClusterMember {
-                        indices: tile_indices.to_vec(),
-                        blurred_colors: tile_blur_buf.to_vec(),
-                    };
-                    if rep.members.len() < max_members_tracked {
-                        rep.members.push(member);
-                    } else {
-                        let pos = rep.insert_cursor % max_members_tracked;
-                        rep.members[pos] = member;
-                        rep.insert_cursor = rep.insert_cursor.wrapping_add(1);
-                    }
-
-                    if rep.members.len() % medoid_recompute_interval == 0 {
-                        Self::recompute_medoid(rep, &orientation_maps);
-                    }
-                }
-                merged += 1;
-            } else {
-                representatives.push(ClusterRep {
-                    indices: tile_indices.to_vec(),
-                    blurred_colors: tile_blur_buf.to_vec(),
-                    members: vec![ClusterMember {
-                        indices: tile_indices.to_vec(),
-                        blurred_colors: tile_blur_buf.to_vec(),
-                    }],
-                    insert_cursor: 1,
-                });
-            }
-        }
-
-        merged
+    if opts.tile_width == 0
+        || opts.tile_height == 0
+        || !width.is_multiple_of(opts.tile_width as u32)
+        || !height.is_multiple_of(opts.tile_height as u32)
+    {
+        log::warn!("Tile reduce post-process skipped due to incompatible dimensions");
+        return Some(0);
     }
 
-    fn expand_indices_to_colors_into(indices: &[u8], palette: &[BGRA8], out: &mut [[u8; 4]]) {
-        for (dst, &idx) in out.iter_mut().zip(indices.iter()) {
-            if let Some(color) = palette.get(idx as usize) {
-                *dst = [color.r, color.g, color.b, color.a];
-            } else {
-                *dst = [0, 0, 0, 0];
-            }
+    let tiles_x = width / opts.tile_width as u32;
+    let tiles_y = height / opts.tile_height as u32;
+    let tile_w = opts.tile_width as usize;
+    let tile_h = opts.tile_height as usize;
+    let tile_area = tile_w * tile_h;
+    let stride = width as usize;
+    let orientation_maps = Orientation::maps(tile_w, tile_h, opts.allow_flip_x, opts.allow_flip_y);
+
+    let mut tile_indices = vec![0u8; tile_area];
+    let mut tile_colors = vec![[0u8; 4]; tile_area];
+    let mut tile_blur = vec![[0u8; 4]; tile_area];
+
+    let mut clusters: Vec<Cluster> = Vec::new();
+    let mut merged = 0usize;
+    let mut oriented_tiles: Vec<Vec<[u8; 4]>> = Vec::with_capacity(orientation_maps.len());
+
+    // Visit tiles from the image center outwards so the representatives that
+    // win are the ones in the middle of the picture.
+    let mut coords: Vec<(u32, u32, f32)> = Vec::with_capacity((tiles_x * tiles_y) as usize);
+    let center_x = tiles_x as f32 / 2.0;
+    let center_y = tiles_y as f32 / 2.0;
+    for ty in 0..tiles_y {
+        for tx in 0..tiles_x {
+            let cx = tx as f32 + 0.5;
+            let cy = ty as f32 + 0.5;
+            let dist2 = (cx - center_x).powi(2) + (cy - center_y).powi(2);
+            coords.push((tx, ty, dist2));
         }
     }
+    coords.sort_by(|a, b| a.2.total_cmp(&b.2));
 
-    fn best_orientation_mse_maps(
-        rep_colors: &[[u8; 4]],
-        tile_colors: &[[u8; 4]],
-        maps: &[OrientationMap],
-    ) -> (f32, Orientation) {
-        let mut best = f32::MAX;
-        let mut best_orientation = Orientation::None;
-        for map in maps {
-            let mse = Self::tile_mse_rgba_with_map(rep_colors, tile_colors, &map.map);
-            if mse < best {
-                best = mse;
-                best_orientation = map.orientation;
-            }
+    for (tx, ty, _) in coords {
+        if cancel.load(Ordering::Relaxed) {
+            return None;
         }
-        (best, best_orientation)
-    }
-
-    fn tile_mse_rgba_with_map(
-        rep_colors: &[[u8; 4]],
-        tile_colors: &[[u8; 4]],
-        map: &[usize],
-    ) -> f32 {
-        if rep_colors.len() != tile_colors.len()
-            || rep_colors.is_empty()
-            || map.len() != rep_colors.len()
-        {
-            return f32::MAX;
-        }
-        let mut error = 0.0f64;
-        for (dst_idx, &src_idx) in map.iter().enumerate() {
-            let rep_px = &rep_colors[src_idx];
-            let tile_px = &tile_colors[dst_idx];
-            for c in 0..4 {
-                let diff = rep_px[c] as f64 - tile_px[c] as f64;
-                error += diff * diff;
-            }
-        }
-        (error / (rep_colors.len() as f64 * 4.0)) as f32
-    }
-
-    fn best_orientation_mse_preoriented(
-        rep_colors: &[[u8; 4]],
-        oriented_tiles: &[Vec<[u8; 4]>],
-        maps: &[OrientationMap],
-    ) -> (f32, Orientation) {
-        let mut best = f32::MAX;
-        let mut best_orientation = Orientation::None;
-        for (orient_buf, map) in oriented_tiles.iter().zip(maps.iter()) {
-            if orient_buf.len() != rep_colors.len() {
-                continue;
-            }
-            let mse = Self::tile_mse_rgba_fast(rep_colors, orient_buf, best);
-            if mse < best {
-                best = mse;
-                best_orientation = map.orientation;
-            }
-        }
-        (best, best_orientation)
-    }
-
-    fn tile_mse_rgba_fast(
-        rep_colors: &[[u8; 4]],
-        tile_colors: &[[u8; 4]],
-        stop_if_over: f32,
-    ) -> f32 {
-        if rep_colors.len() != tile_colors.len() || rep_colors.is_empty() {
-            return f32::MAX;
-        }
-        let mut error = 0.0f64;
-        let stop = (stop_if_over as f64) * (rep_colors.len() as f64 * 4.0);
-        for (rep_px, tile_px) in rep_colors.iter().zip(tile_colors.iter()) {
-            for c in 0..4 {
-                let diff = rep_px[c] as f64 - tile_px[c] as f64;
-                error += diff * diff;
-            }
-            if error > stop {
-                return f32::MAX;
-            }
-        }
-        (error / (rep_colors.len() as f64 * 4.0)) as f32
-    }
-
-    fn orient_tile_to_rep(tile: &[[u8; 4]], map: &[usize]) -> Vec<[u8; 4]> {
-        let mut oriented = vec![[0u8; 4]; tile.len()];
-        for (dst_idx, &rep_idx) in map.iter().enumerate() {
-            oriented[rep_idx] = tile[dst_idx];
-        }
-        oriented
-    }
-
-    fn blur_tile_colors_into(src: &[[u8; 4]], dst: &mut [[u8; 4]], tile_w: usize, tile_h: usize) {
-        let idx = |x: usize, y: usize| y * tile_w + x;
+        let row_offset = |y: usize| ((ty as usize * tile_h + y) * stride) + (tx as usize * tile_w);
         for y in 0..tile_h {
-            for x in 0..tile_w {
-                let mut acc = [0u32; 4];
-                let mut count = 0u32;
-                for dy in y.saturating_sub(1)..=(y + 1).min(tile_h - 1) {
-                    for dx in x.saturating_sub(1)..=(x + 1).min(tile_w - 1) {
-                        let px = &src[idx(dx, dy)];
-                        for c in 0..4 {
-                            acc[c] += px[c] as u32;
-                        }
-                        count += 1;
-                    }
-                }
-                let dst_px = &mut dst[idx(x, y)];
-                for c in 0..4 {
-                    dst_px[c] = (acc[c] / count) as u8;
-                }
-            }
+            let offset = row_offset(y);
+            tile_indices[y * tile_w..(y + 1) * tile_w]
+                .copy_from_slice(&indexed[offset..offset + tile_w]);
         }
+
+        expand_indices_to_colors_into(&tile_indices, palette, &mut tile_colors);
+        blur_tile_colors_into(&tile_colors, &mut tile_blur, tile_w, tile_h);
+
+        oriented_tiles.clear();
+        oriented_tiles.extend(
+            orientation_maps
+                .iter()
+                .map(|map| orient_tile_to_rep(&tile_blur, &map.map)),
+        );
+
+        let matched = clusters.iter().enumerate().find_map(|(idx, cluster)| {
+            let (best_mse, best_orient) = best_orientation_mse_preoriented(
+                &cluster.rep.blurred_colors,
+                &oriented_tiles,
+                &orientation_maps,
+            );
+            (best_mse <= opts.threshold).then_some((idx, best_orient))
+        });
+
+        let tile = Tile {
+            indices: tile_indices.clone(),
+            blurred_colors: tile_blur.clone(),
+        };
+
+        let Some((cluster_idx, orientation)) = matched else {
+            clusters.push(Cluster {
+                rep: tile.clone(),
+                members: vec![tile],
+                insert_cursor: 1,
+            });
+            continue;
+        };
+
+        let cluster = &mut clusters[cluster_idx];
+        let map = orientation_maps
+            .iter()
+            .find(|m| m.orientation == orientation)
+            .map_or(&orientation_maps[0].map, |m| &m.map);
+        for y in 0..tile_h {
+            let offset = row_offset(y);
+            write_rep_row(
+                &mut indexed[offset..offset + tile_w],
+                &cluster.rep.indices,
+                &map[y * tile_w..(y + 1) * tile_w],
+            );
+        }
+
+        if cluster.members.len() < MAX_MEMBERS_TRACKED {
+            cluster.members.push(tile);
+        } else {
+            let pos = cluster.insert_cursor % MAX_MEMBERS_TRACKED;
+            cluster.members[pos] = tile;
+            cluster.insert_cursor = cluster.insert_cursor.wrapping_add(1);
+        }
+        if cluster
+            .members
+            .len()
+            .is_multiple_of(MEDOID_RECOMPUTE_INTERVAL)
+        {
+            recompute_medoid(cluster, &orientation_maps);
+        }
+        merged += 1;
     }
 
-    fn recompute_medoid(rep: &mut ClusterRep, maps: &[OrientationMap]) {
-        if rep.members.len() <= 1 {
-            return;
-        }
-        let mut best_sum = f32::MAX;
-        let mut best_idx = 0usize;
+    Some(merged)
+}
 
-        for (i, a) in rep.members.iter().enumerate() {
-            let mut sum = 0.0f32;
-            for (j, b) in rep.members.iter().enumerate() {
-                if i == j {
-                    continue;
-                }
-                let (mse, _) =
-                    Self::best_orientation_mse_maps(&a.blurred_colors, &b.blurred_colors, maps);
-                sum += mse;
-            }
-            if sum < best_sum {
-                best_sum = sum;
-                best_idx = i;
-            }
-        }
+fn expand_indices_to_colors_into(indices: &[u8], palette: &[BGRA8], out: &mut [[u8; 4]]) {
+    for (dst, &idx) in out.iter_mut().zip(indices) {
+        *dst = palette
+            .get(idx as usize)
+            .map_or([0, 0, 0, 0], |c| [c.r, c.g, c.b, c.a]);
+    }
+}
 
-        if let Some(best) = rep.members.get(best_idx) {
-            rep.indices = best.indices.clone();
-            rep.blurred_colors = best.blurred_colors.clone();
+/// Mean squared error over all channels between `rep` and `tile` read
+/// through `map` (`tile[i]` is compared with `rep[map[i]]`).
+fn tile_mse_with_map(rep: &[[u8; 4]], tile: &[[u8; 4]], map: &[usize]) -> f32 {
+    if rep.len() != tile.len() || rep.is_empty() || map.len() != rep.len() {
+        return f32::MAX;
+    }
+    let error: u64 = map
+        .iter()
+        .zip(tile)
+        .map(|(&src_idx, tile_px)| squared_diff(&rep[src_idx], tile_px))
+        .sum();
+    error as f32 / (rep.len() * 4) as f32
+}
+
+/// Like [`tile_mse_with_map`] on already oriented tiles, giving up as soon as
+/// the error exceeds `stop_if_over` since the caller only wants the minimum.
+fn tile_mse_fast(rep: &[[u8; 4]], tile: &[[u8; 4]], stop_if_over: f32) -> f32 {
+    if rep.len() != tile.len() || rep.is_empty() {
+        return f32::MAX;
+    }
+    let samples = (rep.len() * 4) as f32;
+    let stop = (stop_if_over * samples) as u64;
+    let mut error = 0u64;
+    for (rep_px, tile_px) in rep.iter().zip(tile) {
+        error += squared_diff(rep_px, tile_px);
+        if error > stop {
+            return f32::MAX;
         }
     }
+    error as f32 / samples
+}
 
-    fn write_rep_with_orientation(
-        dest_row: &mut [u8],
-        rep_indices: &[u8],
-        tile_w: usize,
-        _tile_h: usize,
-        y: usize,
-        orientation_map: &[usize],
-    ) {
-        let row_offset = y * tile_w;
+fn squared_diff(a: &[u8; 4], b: &[u8; 4]) -> u64 {
+    a.iter()
+        .zip(b)
+        .map(|(&x, &y)| {
+            let d = x as i32 - y as i32;
+            (d * d) as u64
+        })
+        .sum()
+}
+
+fn best_orientation_mse_maps(
+    rep: &[[u8; 4]],
+    tile: &[[u8; 4]],
+    maps: &[OrientationMap],
+) -> (f32, Orientation) {
+    maps.iter()
+        .map(|map| (tile_mse_with_map(rep, tile, &map.map), map.orientation))
+        .min_by(|a, b| a.0.total_cmp(&b.0))
+        .unwrap_or((f32::MAX, Orientation::None))
+}
+
+fn best_orientation_mse_preoriented(
+    rep: &[[u8; 4]],
+    oriented_tiles: &[Vec<[u8; 4]>],
+    maps: &[OrientationMap],
+) -> (f32, Orientation) {
+    let mut best = f32::MAX;
+    let mut best_orientation = Orientation::None;
+    for (oriented, map) in oriented_tiles.iter().zip(maps) {
+        let mse = tile_mse_fast(rep, oriented, best);
+        if mse < best {
+            best = mse;
+            best_orientation = map.orientation;
+        }
+    }
+    (best, best_orientation)
+}
+
+fn orient_tile_to_rep(tile: &[[u8; 4]], map: &[usize]) -> Vec<[u8; 4]> {
+    let mut oriented = vec![[0u8; 4]; tile.len()];
+    for (dst_idx, &rep_idx) in map.iter().enumerate() {
+        oriented[rep_idx] = tile[dst_idx];
+    }
+    oriented
+}
+
+/// 3x3 box blur, clamped at the tile edges.
+fn blur_tile_colors_into(src: &[[u8; 4]], dst: &mut [[u8; 4]], tile_w: usize, tile_h: usize) {
+    let idx = |x: usize, y: usize| y * tile_w + x;
+    for y in 0..tile_h {
         for x in 0..tile_w {
-            let src_idx = orientation_map[row_offset + x];
-            dest_row[x] = rep_indices[src_idx];
+            let mut acc = [0u32; 4];
+            let mut count = 0u32;
+            for dy in y.saturating_sub(1)..=(y + 1).min(tile_h - 1) {
+                for dx in x.saturating_sub(1)..=(x + 1).min(tile_w - 1) {
+                    let px = &src[idx(dx, dy)];
+                    for c in 0..4 {
+                        acc[c] += px[c] as u32;
+                    }
+                    count += 1;
+                }
+            }
+            let dst_px = &mut dst[idx(x, y)];
+            for c in 0..4 {
+                dst_px[c] = (acc[c] / count) as u8;
+            }
         }
+    }
+}
+
+/// Make the member closest to all the others the cluster's representative.
+fn recompute_medoid(cluster: &mut Cluster, maps: &[OrientationMap]) {
+    if cluster.members.len() <= 1 {
+        return;
+    }
+    let medoid = cluster
+        .members
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            let sum: f32 = cluster
+                .members
+                .iter()
+                .enumerate()
+                .filter(|&(j, _)| j != i)
+                .map(|(_, b)| {
+                    best_orientation_mse_maps(&a.blurred_colors, &b.blurred_colors, maps).0
+                })
+                .sum();
+            (sum, i)
+        })
+        .min_by(|a, b| a.0.total_cmp(&b.0))
+        .map(|(_, i)| i);
+    if let Some(i) = medoid {
+        cluster.rep = cluster.members[i].clone();
+    }
+}
+
+/// Write one row of the representative into `dest_row`, `map_row[x]` naming
+/// the representative pixel that lands at column `x`.
+fn write_rep_row(dest_row: &mut [u8], rep_indices: &[u8], map_row: &[usize]) {
+    for (dst, &src_idx) in dest_row.iter_mut().zip(map_row) {
+        *dst = rep_indices[src_idx];
     }
 }
 
@@ -644,26 +539,27 @@ impl Orientation {
         v
     }
 
+    /// For every allowed orientation, the source pixel index for each
+    /// destination pixel of a `tile_w` x `tile_h` tile.
     fn maps(
         tile_w: usize,
         tile_h: usize,
         allow_flip_x: bool,
         allow_flip_y: bool,
     ) -> Vec<OrientationMap> {
-        let orientations = Orientation::available(allow_flip_x, allow_flip_y);
-        orientations
+        Orientation::available(allow_flip_x, allow_flip_y)
             .into_iter()
             .map(|orientation| {
                 let mut map = Vec::with_capacity(tile_w * tile_h);
                 for y in 0..tile_h {
                     for x in 0..tile_w {
-                        let idx = match orientation {
-                            Orientation::None => y * tile_w + x,
-                            Orientation::FlipX => y * tile_w + (tile_w - 1 - x),
-                            Orientation::FlipY => (tile_h - 1 - y) * tile_w + x,
-                            Orientation::FlipXY => (tile_h - 1 - y) * tile_w + (tile_w - 1 - x),
+                        let (sx, sy) = match orientation {
+                            Orientation::None => (x, y),
+                            Orientation::FlipX => (tile_w - 1 - x, y),
+                            Orientation::FlipY => (x, tile_h - 1 - y),
+                            Orientation::FlipXY => (tile_w - 1 - x, tile_h - 1 - y),
                         };
-                        map.push(idx);
+                        map.push(sy * tile_w + sx);
                     }
                 }
                 OrientationMap { orientation, map }
@@ -679,12 +575,140 @@ struct OrientationMap {
 
 /// Qualetize consumes BGRA, egui produces RGBA.
 fn to_bgra(rgba: &[u8]) -> Vec<BGRA8> {
-    rgba.chunks_exact(4)
-        .map(|px| BGRA8 {
-            b: px[2],
-            g: px[1],
-            r: px[0],
-            a: px[3],
-        })
+    rgba.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&[r, g, b, a]| BGRA8 { b, g, r, a })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tiles are 4x1 so the 3x3 blur (which averages a whole 2x2 tile into
+    /// one color) still leaves a mirrored tile distinguishable from the original.
+    fn opts(threshold: f32, flip_x: bool, flip_y: bool) -> TileReduceOptions {
+        TileReduceOptions {
+            tile_width: 4,
+            tile_height: 1,
+            threshold,
+            allow_flip_x: flip_x,
+            allow_flip_y: flip_y,
+        }
+    }
+
+    fn gray_palette() -> Vec<BGRA8> {
+        (0..8u8)
+            .map(|i| BGRA8 {
+                b: i * 30,
+                g: i * 30,
+                r: i * 30,
+                a: 255,
+            })
+            .collect()
+    }
+
+    /// 8x1 image, 4x1 tiles: the right tile is the horizontal mirror of the left one.
+    #[rustfmt::skip]
+    fn mirrored_pair() -> Vec<u8> {
+        vec![0, 0, 7, 7,   7, 7, 0, 0]
+    }
+
+    fn reduce(pixels: &mut [u8], opts: &TileReduceOptions, cancelled: bool) -> Option<usize> {
+        reduce_tiles_indexed(
+            pixels,
+            &gray_palette(),
+            8,
+            1,
+            opts,
+            &AtomicBool::new(cancelled),
+        )
+    }
+
+    #[test]
+    fn identical_tiles_are_merged_with_a_zero_threshold() {
+        #[rustfmt::skip]
+        let mut pixels = vec![1, 2, 3, 4,   1, 2, 3, 4];
+        assert_eq!(
+            reduce(&mut pixels, &opts(0.0, false, false), false),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn a_mirrored_tile_is_only_merged_when_the_flip_is_allowed() {
+        let mut pixels = mirrored_pair();
+        assert_eq!(
+            reduce(&mut pixels, &opts(0.0, false, false), false),
+            Some(0)
+        );
+        assert_eq!(pixels, mirrored_pair(), "nothing rewritten");
+
+        let mut pixels = mirrored_pair();
+        assert_eq!(reduce(&mut pixels, &opts(0.0, true, false), false), Some(1));
+        // The merged tile is written as the flipped representative, so the
+        // image resolves to the same colors it had before.
+        assert_eq!(pixels, mirrored_pair());
+    }
+
+    #[test]
+    fn a_raised_cancel_flag_stops_the_reduction() {
+        let mut pixels = mirrored_pair();
+        assert_eq!(reduce(&mut pixels, &opts(0.0, true, true), true), None);
+    }
+
+    #[test]
+    fn indivisible_dimensions_are_skipped() {
+        let mut pixels = vec![0; 6];
+        let merged = reduce_tiles_indexed(
+            &mut pixels,
+            &gray_palette(),
+            6,
+            1,
+            &opts(0.0, false, false),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(merged, Some(0));
+    }
+
+    #[test]
+    fn mse_helpers_agree_and_flipped_maps_line_up() {
+        let maps = Orientation::maps(2, 2, true, true);
+        let rep = vec![
+            [10, 0, 0, 255],
+            [20, 0, 0, 255],
+            [30, 0, 0, 255],
+            [40, 0, 0, 255],
+        ];
+        // rep flipped horizontally
+        let tile = vec![
+            [20, 0, 0, 255],
+            [10, 0, 0, 255],
+            [40, 0, 0, 255],
+            [30, 0, 0, 255],
+        ];
+
+        let (mse, orientation) = best_orientation_mse_maps(&rep, &tile, &maps);
+        assert_eq!(mse, 0.0);
+        assert!(orientation == Orientation::FlipX);
+
+        let oriented: Vec<_> = maps
+            .iter()
+            .map(|m| orient_tile_to_rep(&tile, &m.map))
+            .collect();
+        let (mse, orientation) = best_orientation_mse_preoriented(&rep, &oriented, &maps);
+        assert_eq!(mse, 0.0);
+        assert!(orientation == Orientation::FlipX);
+
+        // Identity orientation: every pixel differs by 10 in one channel.
+        assert_eq!(tile_mse_with_map(&rep, &tile, &maps[0].map), 100.0 / 4.0);
+        assert_eq!(tile_mse_fast(&rep, &tile, f32::MAX), 100.0 / 4.0);
+    }
+
+    #[test]
+    fn bgra_conversion_swaps_red_and_blue() {
+        let bgra = to_bgra(&[1, 2, 3, 4]);
+        assert_eq!((bgra[0].r, bgra[0].g, bgra[0].b, bgra[0].a), (1, 2, 3, 4));
+    }
 }

--- a/src/settings_manager/mod.rs
+++ b/src/settings_manager/mod.rs
@@ -5,12 +5,31 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+/// Write `bytes` to `path` without ever leaving a truncated file behind.
+///
+/// Writes go to a sibling `<path>.tmp` file first and are only made visible by an
+/// atomic rename over the real target, so a crash or power loss mid-write can lose
+/// the new content but never corrupts what was already on disk.
+pub(crate) fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut tmp_name = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp_path = Path::new(&tmp_name);
+
+    fs::write(tmp_path, bytes)?;
+    fs::rename(tmp_path, path)
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettingsBundle {
     pub qualetize_settings: QualetizeSettings,
     pub color_correction: ColorCorrection,
     #[serde(default)]
     pub sort_settings: PaletteSortSettings,
+    #[serde(default)]
     pub version: String,
 }
 
@@ -39,7 +58,8 @@ impl SettingsBundle {
         let json_data = serde_json::to_string_pretty(self)
             .map_err(|e| format!("Failed to serialize settings: {e}"))?;
 
-        fs::write(&path, json_data).map_err(|e| format!("Failed to write settings file: {e}"))?;
+        write_atomically(path.as_ref(), json_data.as_bytes())
+            .map_err(|e| format!("Failed to write settings file: {e}"))?;
 
         log::info!("Settings saved to: {}", path.as_ref().display());
         Ok(())
@@ -49,8 +69,13 @@ impl SettingsBundle {
         let json_data =
             fs::read_to_string(&path).map_err(|e| format!("Failed to read settings file: {e}"))?;
 
-        let settings = serde_json::from_str::<SettingsBundle>(&json_data)
+        let mut settings = serde_json::from_str::<SettingsBundle>(&json_data)
             .map_err(|e| format!("Failed to parse settings file: {e}"))?;
+
+        // A hand-edited or older-version `.qset` may carry out-of-range values;
+        // clamp them before they can reach the C library. See
+        // `QualetizeSettings::sanitize`.
+        settings.qualetize_settings.sanitize();
 
         log::info!("Settings loaded from: {}", path.as_ref().display());
         Ok(settings)
@@ -85,7 +110,22 @@ impl SettingsBundle {
 
     /// Restore the settings from the last run, falling back to the defaults.
     pub fn load_session() -> Self {
-        let bundle = Self::session_path().and_then(|path| Self::load_from_file(path).ok());
+        let bundle = Self::session_path().and_then(|path| {
+            if !path.exists() {
+                // Nothing to restore yet, e.g. first run: not worth a warning.
+                return None;
+            }
+            match Self::load_from_file(&path) {
+                Ok(bundle) => Some(bundle),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to load session settings from {}: {e}",
+                        path.display()
+                    );
+                    None
+                }
+            }
+        });
 
         bundle.unwrap_or_else(|| {
             Self::new(
@@ -159,6 +199,48 @@ mod tests {
         // Predates the flag, and back then correction was always applied.
         assert!(bundle.color_correction.enabled);
         assert_eq!(bundle.sort_settings, PaletteSortSettings::default());
+    }
+
+    /// `version` is written but never read back, so a file saved before it existed
+    /// (or hand-trimmed) must still load rather than fail to parse.
+    #[test]
+    fn a_bundle_missing_the_version_field_still_loads() {
+        let json = r#"{
+            "qualetize_settings": {
+                "tile_width": 8, "tile_height": 8, "n_palettes": 1, "n_colors": 16,
+                "rgba_depth": "3331", "premul_alpha": false, "color_space": "RgbLinear",
+                "dither_mode": "Floyd", "dither_level": 0.5, "tile_passes": 1000,
+                "color_passes": 100, "col0_is_clear": false, "clear_color": "None"
+            },
+            "color_correction": {
+                "brightness": 0.0, "contrast": 1.0, "gamma": 1.0, "saturation": 1.0,
+                "hue_shift": 0.0, "shadows": 0.0, "highlights": 0.0
+            }
+        }"#;
+
+        let bundle: SettingsBundle = serde_json::from_str(json).expect("loads");
+        assert_eq!(bundle.version, "");
+    }
+
+    /// `examples/genesis.qset` ships as a ready-to-use example: it must still load,
+    /// and its `color_correction.enabled` must be explicit (`false`) rather than
+    /// relying on the "missing means true" backwards-compatibility default, which
+    /// would otherwise silently turn color correction on for this example.
+    #[test]
+    fn the_genesis_example_loads_disabled_and_matches_the_preset() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/genesis.qset");
+        let bundle = SettingsBundle::load_from_file(&path).expect("example loads");
+
+        assert!(!bundle.color_correction.enabled);
+
+        let preset = QualetizeSettings::genesis();
+        assert_eq!(
+            bundle.qualetize_settings, preset,
+            "loaded settings (left) do not match QualetizeSettings::genesis() (right):\n\
+             loaded:  {:#?}\n\
+             genesis: {:#?}",
+            bundle.qualetize_settings, preset
+        );
     }
 
     #[test]

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -39,10 +39,11 @@ impl Default for TileCountSettings {
     }
 }
 
+/// How unique tiles are counted, and whether the counts in `AppState` are
+/// stale. The counts themselves live next to the images they describe.
 #[derive(Debug, Clone, Default)]
 pub struct TileCountState {
     pub settings: TileCountSettings,
-    pub last_count: Option<usize>,
     pub dirty: bool,
 }
 
@@ -55,14 +56,8 @@ impl TileCountState {
         }
     }
 
-    /// Force a recount on the next draw, keeping the stale number visible until then.
+    /// Force a recount on the next frame, keeping the stale number visible until then.
     pub fn mark_dirty(&mut self) {
-        self.dirty = true;
-    }
-
-    /// Force a recount and clear the displayed number, for when the image itself is gone.
-    pub fn reset(&mut self) {
-        self.last_count = None;
         self.dirty = true;
     }
 }
@@ -129,10 +124,12 @@ pub struct AppState {
     pub base_output_image: Option<ImageData>,
     pub output_image: Option<ImageData>,
     pub output_palette_sorted_indexed_image: Option<ImageDataIndexed>,
+    /// Unique tiles in `base_output_image` and `output_image`, recounted
+    /// whenever `tile_count.dirty` is set.
     pub base_tile_count: Option<usize>,
     pub reduced_tile_count: Option<usize>,
+    /// Mirrored from the processor once per frame for the panel spinners.
     pub tile_reduce_processing: bool,
-    pub tile_reduce_generation_id: u64,
     pub tile_reduce_toast: Option<Toast>,
 
     /// Set only while the loaded image needs extending; the input image itself
@@ -216,7 +213,6 @@ impl Default for AppState {
             base_tile_count: None,
             reduced_tile_count: None,
             tile_reduce_processing: false,
-            tile_reduce_generation_id: 0,
             tile_reduce_toast: None,
             tile_fitted_input: None,
             tile_fit_toast: None,
@@ -327,7 +323,7 @@ impl AppState {
         if self.preferences != self.last_preferences {
             self.last_preferences = self.preferences.clone();
             if let Err(e) = self.preferences.save() {
-                eprintln!("Failed to save preferences: {e}");
+                log::error!("Failed to save preferences: {e}");
             }
         }
     }
@@ -347,6 +343,13 @@ impl AppState {
     pub fn clear_palette_sort_dirty(&mut self) {
         self.last_palette_sort_settings = self.palette_sort_settings;
         self.palette_sort_dirty = false;
+    }
+
+    /// Schedule a (debounced) re-quantization of the color corrected image.
+    pub fn request_qualetize(&mut self) {
+        self.request_update_qualetized_image = Some(QualetizeRequest {
+            time: Instant::now(),
+        });
     }
 
     /// Check if color correction settings have changed
@@ -372,7 +375,6 @@ impl AppState {
         self.reduced_tile_count = None;
         self.request_update_tile_reduce = false;
         self.invalidate_palette_sort();
-        self.tile_count.reset();
     }
 
     /// Whether `source` currently has something to export. The optional passes

--- a/src/types/color_space.rs
+++ b/src/types/color_space.rs
@@ -80,3 +80,24 @@ impl ColorSpace {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins each variant's id to the `COLOURSPACE_*` constants in
+    /// `external/qualetize/include/Qualetize.h`.
+    #[test]
+    fn ids_match_the_header_constants() {
+        assert_eq!(ColorSpace::Srgb.to_id(), 0);
+        assert_eq!(ColorSpace::RgbLinear.to_id(), 1);
+        assert_eq!(ColorSpace::Ycbcr.to_id(), 2);
+        assert_eq!(ColorSpace::Ycocg.to_id(), 3);
+        assert_eq!(ColorSpace::Cielab.to_id(), 4);
+        assert_eq!(ColorSpace::Ictcp.to_id(), 5);
+        assert_eq!(ColorSpace::Oklab.to_id(), 6);
+        assert_eq!(ColorSpace::RgbPsy.to_id(), 7);
+        assert_eq!(ColorSpace::YcbcrPsy.to_id(), 8);
+        assert_eq!(ColorSpace::YcocgPsy.to_id(), 9);
+    }
+}

--- a/src/types/dither.rs
+++ b/src/types/dither.rs
@@ -44,18 +44,22 @@ impl DitherMode {
         }
     }
 
+    /// Matches the C header's `DITHER_*` constants (`external/qualetize/include/Qualetize.h`):
+    /// `DITHER_ORDERED(n)` is `n` itself, with a kernel of size `(2^n) x (2^n)`, so `OrdN`
+    /// maps to `log2(N)` rather than to `N`. The CLI's mapping table
+    /// (`external/qualetize/source/qualetize-cli.c`) confirms `ord2..ord64` -> `1..=6`.
     pub fn to_id(self) -> u8 {
         match self {
             DitherMode::None => 0,
             DitherMode::Floyd => 0xFE,
             DitherMode::Atkinson => 0xFD,
             DitherMode::Checker => 0xFF,
-            DitherMode::Ord2 => 2,
-            DitherMode::Ord4 => 4,
-            DitherMode::Ord8 => 6,
-            DitherMode::Ord16 => 7,
-            DitherMode::Ord32 => 8,
-            DitherMode::Ord64 => 9,
+            DitherMode::Ord2 => 1,
+            DitherMode::Ord4 => 2,
+            DitherMode::Ord8 => 3,
+            DitherMode::Ord16 => 4,
+            DitherMode::Ord32 => 5,
+            DitherMode::Ord64 => 6,
         }
     }
 
@@ -72,5 +76,31 @@ impl DitherMode {
             DitherMode::Ord32,
             DitherMode::Ord64,
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `DITHER_ORDERED(n)` in Qualetize.h is `n` itself (kernel `(2^n) x (2^n)`), so
+    /// each `OrdN` variant must map to `log2(N)`, not to `N`.
+    #[test]
+    fn ordered_dither_ids_are_log2_of_the_kernel_size() {
+        assert_eq!(DitherMode::Ord2.to_id(), 1);
+        assert_eq!(DitherMode::Ord4.to_id(), 2);
+        assert_eq!(DitherMode::Ord8.to_id(), 3);
+        assert_eq!(DitherMode::Ord16.to_id(), 4);
+        assert_eq!(DitherMode::Ord32.to_id(), 5);
+        assert_eq!(DitherMode::Ord64.to_id(), 6);
+    }
+
+    /// Non-ordered modes are fixed sentinel values defined by the C header.
+    #[test]
+    fn non_ordered_dither_ids_match_the_header_constants() {
+        assert_eq!(DitherMode::None.to_id(), 0);
+        assert_eq!(DitherMode::Floyd.to_id(), 0xFE);
+        assert_eq!(DitherMode::Atkinson.to_id(), 0xFD);
+        assert_eq!(DitherMode::Checker.to_id(), 0xFF);
     }
 }

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -1,7 +1,6 @@
 use super::BGRA8;
 use super::ColorCorrection;
 use crate::color_processor::ColorProcessor;
-use crate::image_processor::QualetizeResult;
 use egui::{Color32, ColorImage, TextureHandle};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -87,6 +86,44 @@ impl SortMode {
 }
 
 impl ImageDataIndexed {
+    /// `palettes` is the flat palette buffer as the library produces it; the
+    /// per-palette rows for the UI are derived from it here so the two can
+    /// never disagree.
+    pub fn new(palettes: Vec<BGRA8>, colors_per_palette: usize, indexed_pixels: Vec<u8>) -> Self {
+        let palettes_for_ui = palettes
+            .chunks(colors_per_palette.max(1))
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|c| Color32::from_rgba_unmultiplied(c.r, c.g, c.b, c.a))
+                    .collect()
+            })
+            .collect();
+        Self {
+            palettes_for_ui,
+            palettes,
+            indexed_pixels,
+        }
+    }
+
+    pub fn colors_per_palette(&self) -> usize {
+        self.palettes_for_ui.first().map_or(0, Vec::len)
+    }
+
+    /// Every pixel resolved through the palette, as RGBA bytes. Indices past
+    /// the end of the palette come out opaque black.
+    pub fn to_rgba(&self) -> Vec<u8> {
+        let mut pixels = Vec::with_capacity(self.indexed_pixels.len() * 4);
+        for &index in &self.indexed_pixels {
+            let px = self
+                .palettes
+                .get(index as usize)
+                .map_or([0, 0, 0, 255], |c| [c.r, c.g, c.b, c.a]);
+            pixels.extend_from_slice(&px);
+        }
+        pixels
+    }
+
     /// Reorder the colors inside every palette, rewriting the pixel indices so
     /// each pixel still resolves to the same color.
     pub fn sorted(
@@ -95,15 +132,11 @@ impl ImageDataIndexed {
         order: SortOrder,
         first_color_is_transparent: bool,
     ) -> Self {
-        let Some(first_palette) = self.palettes_for_ui.first() else {
-            return self.clone();
-        };
-        let colors_per_palette = first_palette.len();
+        let colors_per_palette = self.colors_per_palette();
         if colors_per_palette == 0 {
             return self.clone();
         }
 
-        let mut new_palettes_for_ui = self.palettes_for_ui.clone();
         let mut new_palettes = self.palettes.clone();
 
         // One global old-index -> new-index table for every palette, so the
@@ -125,7 +158,6 @@ impl ImageDataIndexed {
             });
 
             for (new_idx, &old_idx) in order_of.iter().enumerate() {
-                new_palettes_for_ui[palette_idx][new_idx] = palette[old_idx];
                 new_palettes[palette_start + new_idx] = self.palettes[palette_start + old_idx];
                 if let Some(slot) = remap.get_mut(palette_start + old_idx) {
                     *slot = (palette_start + new_idx) as u8;
@@ -133,15 +165,12 @@ impl ImageDataIndexed {
             }
         }
 
-        ImageDataIndexed {
-            palettes_for_ui: new_palettes_for_ui,
-            palettes: new_palettes,
-            indexed_pixels: self
-                .indexed_pixels
-                .iter()
-                .map(|&pixel| remap[pixel as usize])
-                .collect(),
-        }
+        let indexed_pixels = self
+            .indexed_pixels
+            .iter()
+            .map(|&pixel| remap[pixel as usize])
+            .collect();
+        Self::new(new_palettes, colors_per_palette, indexed_pixels)
     }
 
     /// Ordering of two entries of the same palette. When the first color is the
@@ -234,18 +263,6 @@ impl ImageData {
         }
     }
 
-    /// Get the color of the top-left pixel (0, 0)
-    pub fn get_top_left_pixel_color(&self) -> Option<Color32> {
-        if self.rgba_data.len() >= 4 && self.width > 0 && self.height > 0 {
-            let r = self.rgba_data[0];
-            let g = self.rgba_data[1];
-            let b = self.rgba_data[2];
-            Some(Color32::from_rgb(r, g, b))
-        } else {
-            None
-        }
-    }
-
     pub fn color_corrected(
         &self,
         color_correction: &ColorCorrection,
@@ -276,76 +293,25 @@ impl ImageData {
         }
     }
 
-    pub fn create_from_qualetize_result(
-        result: QualetizeResult,
+    /// An indexed image together with the RGBA texture it resolves to.
+    pub fn from_indexed(
+        indexed: ImageDataIndexed,
+        width: u32,
+        height: u32,
         ctx: &egui::Context,
-    ) -> Result<ImageData, String> {
-        let QualetizeResult {
-            indexed_data,
-            palette_data,
-            settings,
-            width,
-            height,
-            generation_id: _,
-        } = result;
-
-        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
-        for &pixel_index in &indexed_data {
-            let palette_index = pixel_index as usize;
-            if palette_index < palette_data.len() {
-                let color = &palette_data[palette_index];
-                pixels.extend_from_slice(&[color.r, color.g, color.b, color.a]);
-            } else {
-                pixels.extend_from_slice(&[0, 0, 0, 255]);
-            }
-        }
-
+    ) -> ImageData {
+        let pixels = indexed.to_rgba();
         let size = [width as usize, height as usize];
         let color_image = ColorImage::from_rgba_unmultiplied(size, &pixels);
         let texture = ctx.load_texture("output", color_image, egui::TextureOptions::NEAREST);
 
-        // Split the flat palette into per-palette rows for the overlay.
-        let palettes_for_ui = Self::convert_palette_data(
-            &palette_data,
-            settings.n_palettes as usize,
-            settings.n_colors as usize,
-        );
-
-        Ok(ImageData {
+        ImageData {
             texture,
             width,
             height,
             rgba_data: pixels,
-            indexed: Some(ImageDataIndexed {
-                palettes_for_ui,
-                palettes: palette_data,
-                indexed_pixels: indexed_data,
-            }),
-        })
-    }
-    fn convert_palette_data(
-        palette_data: &[BGRA8],
-        n_palettes: usize,
-        n_colors: usize,
-    ) -> Vec<Vec<egui::Color32>> {
-        let colors_per_palette = n_colors;
-        let mut palettes = Vec::new();
-
-        let egui_colors: Vec<egui::Color32> = palette_data
-            .iter()
-            .map(|bgra| egui::Color32::from_rgba_unmultiplied(bgra.r, bgra.g, bgra.b, bgra.a))
-            .collect();
-
-        for chunk in egui_colors.chunks(colors_per_palette) {
-            palettes.push(chunk.to_vec());
+            indexed: Some(indexed),
         }
-
-        while palettes.len() < n_palettes {
-            palettes.push(vec![egui::Color32::BLACK; colors_per_palette]);
-        }
-        palettes.truncate(n_palettes);
-
-        palettes
     }
 
     pub fn count_unique_tiles(
@@ -396,39 +362,14 @@ impl ImageData {
                     continue;
                 }
 
-                let base = tile;
-                let mut best = base.clone();
-
-                if options.allow_flip_x {
-                    let mut flipped = Vec::with_capacity(tile_area);
-                    for y in 0..tile_h {
-                        let row_start = y * tile_w;
-                        let row = &base[row_start..row_start + tile_w];
-                        flipped.extend(row.iter().rev());
+                // Canonical form: the smallest of the tile and its allowed
+                // flips, so mirrored tiles collapse into one entry.
+                let mut best = tile.clone();
+                for (flip_x, flip_y) in [(true, false), (false, true), (true, true)] {
+                    if (flip_x && !options.allow_flip_x) || (flip_y && !options.allow_flip_y) {
+                        continue;
                     }
-                    if flipped < best {
-                        best = flipped;
-                    }
-                }
-
-                if options.allow_flip_y {
-                    let mut flipped = Vec::with_capacity(tile_area);
-                    for y in (0..tile_h).rev() {
-                        let row_start = y * tile_w;
-                        flipped.extend_from_slice(&base[row_start..row_start + tile_w]);
-                    }
-                    if flipped < best {
-                        best = flipped;
-                    }
-                }
-
-                if options.allow_flip_x && options.allow_flip_y {
-                    let mut flipped = Vec::with_capacity(tile_area);
-                    for y in (0..tile_h).rev() {
-                        let row_start = y * tile_w;
-                        let row = &base[row_start..row_start + tile_w];
-                        flipped.extend(row.iter().rev());
-                    }
+                    let flipped = flip_tile(&tile, tile_w, flip_x, flip_y);
                     if flipped < best {
                         best = flipped;
                     }
@@ -457,6 +398,23 @@ impl ImageData {
             indexed: None,
         })
     }
+}
+
+/// `tile` (row-major, `tile_w` wide) mirrored along the requested axes.
+fn flip_tile(tile: &[u8], tile_w: usize, flip_x: bool, flip_y: bool) -> Vec<u8> {
+    let mut rows: Vec<&[u8]> = tile.chunks_exact(tile_w).collect();
+    if flip_y {
+        rows.reverse();
+    }
+    let mut flipped = Vec::with_capacity(tile.len());
+    for row in rows {
+        if flip_x {
+            flipped.extend(row.iter().rev());
+        } else {
+            flipped.extend_from_slice(row);
+        }
+    }
+    flipped
 }
 
 /// Place `src` at the top left of a `width` x `height` RGBA buffer, filling the
@@ -508,7 +466,7 @@ mod tests {
         assert_eq!(&out[8..12], &fill, "padding to the right");
         assert_eq!(&out[12..16], &fill, "padding to the right");
         assert!(
-            out[16..].chunks_exact(4).all(|px| px == fill),
+            out[16..].as_chunks::<4>().0.iter().all(|px| *px == fill),
             "every added row is filled"
         );
     }
@@ -532,15 +490,7 @@ mod tests {
         colors_per_palette: usize,
         pixels: Vec<u8>,
     ) -> ImageDataIndexed {
-        let palettes_for_ui = palettes
-            .chunks(colors_per_palette)
-            .map(|chunk| chunk.iter().map(ui_color).collect())
-            .collect();
-        ImageDataIndexed {
-            palettes_for_ui,
-            palettes,
-            indexed_pixels: pixels,
-        }
+        ImageDataIndexed::new(palettes, colors_per_palette, pixels)
     }
 
     fn opts(visible_only: bool, flip_x: bool, flip_y: bool) -> TileCountOptions {
@@ -696,11 +646,7 @@ mod tests {
 
     #[test]
     fn sorted_is_a_noop_without_palettes() {
-        let empty = ImageDataIndexed {
-            palettes_for_ui: Vec::new(),
-            palettes: Vec::new(),
-            indexed_pixels: vec![0, 1, 2],
-        };
+        let empty = ImageDataIndexed::new(Vec::new(), 4, vec![0, 1, 2]);
         let sorted = empty.sorted(SortMode::Luminance, SortOrder::Ascending, false);
         assert_eq!(sorted.indexed_pixels, vec![0, 1, 2]);
     }

--- a/src/types/preferences.rs
+++ b/src/types/preferences.rs
@@ -32,19 +32,22 @@ mod color32_def {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserPreferences {
+    #[serde(default)]
     pub show_advanced: bool,
+    #[serde(default)]
     pub show_palettes: bool,
 
     #[serde(default)]
     pub show_debug_info: bool,
     #[serde(default)]
     pub show_appearance: bool,
+    #[serde(default)]
     pub selected_export_format: ExportFormat,
 
     #[serde(default)]
     pub appearance_mode: AppearanceMode,
 
-    #[serde(with = "color32_def")]
+    #[serde(default, with = "color32_def")]
     pub background_color: Option<Color32>,
 }
 
@@ -73,21 +76,55 @@ impl UserPreferences {
 
     pub fn load() -> Self {
         let path = Self::config_path();
-        if let Ok(content) = std::fs::read_to_string(&path)
-            && let Ok(prefs) = serde_json::from_str(&content)
-        {
-            return prefs;
+        // A missing file just means first run: not worth a warning, so only the
+        // parse failure of an existing file is logged.
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            match serde_json::from_str(&content) {
+                Ok(prefs) => return prefs,
+                Err(e) => log::warn!("Failed to parse preferences at {}: {e}", path.display()),
+            }
         }
         Self::default()
     }
 
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
         let path = Self::config_path();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
         let content = serde_json::to_string_pretty(self)?;
-        std::fs::write(&path, content)?;
+        crate::settings_manager::write_atomically(&path, content.as_bytes())?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every field carries `#[serde(default)]`, so a completely empty preferences
+    /// file (e.g. `{}`, or one truncated by a crash) still deserializes instead of
+    /// failing to load.
+    #[test]
+    fn an_empty_preferences_object_still_deserializes() {
+        let prefs: UserPreferences = serde_json::from_str("{}").expect("loads");
+        assert_eq!(prefs.selected_export_format, ExportFormat::PngIndexed);
+        assert_eq!(prefs.background_color, None);
+    }
+
+    /// A preferences file written before a field existed is missing just that one
+    /// key; it must still load, with the missing field taking its serde default.
+    #[test]
+    fn a_preferences_object_missing_one_field_still_deserializes() {
+        let json = r#"{
+            "show_advanced": true,
+            "show_debug_info": true,
+            "show_appearance": true,
+            "selected_export_format": "Bmp",
+            "appearance_mode": "Dark"
+        }"#;
+
+        let prefs: UserPreferences = serde_json::from_str(json).expect("loads");
+        assert!(prefs.show_advanced);
+        assert_eq!(prefs.selected_export_format, ExportFormat::Bmp);
+        // "show_palettes" was omitted: falls back to bool's serde default.
+        assert!(!prefs.show_palettes);
     }
 }

--- a/src/types/preferences.rs
+++ b/src/types/preferences.rs
@@ -38,8 +38,6 @@ pub struct UserPreferences {
     pub show_palettes: bool,
 
     #[serde(default)]
-    pub show_debug_info: bool,
-    #[serde(default)]
     pub show_appearance: bool,
     #[serde(default)]
     pub selected_export_format: ExportFormat,
@@ -56,7 +54,6 @@ impl Default for UserPreferences {
         Self {
             show_advanced: false,
             show_palettes: true,
-            show_debug_info: false,
             show_appearance: false,
             selected_export_format: ExportFormat::default(),
             appearance_mode: AppearanceMode::default(),
@@ -115,7 +112,6 @@ mod tests {
     fn a_preferences_object_missing_one_field_still_deserializes() {
         let json = r#"{
             "show_advanced": true,
-            "show_debug_info": true,
             "show_appearance": true,
             "selected_export_format": "Bmp",
             "appearance_mode": "Dark"

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -9,13 +9,16 @@ use std::sync::LazyLock;
 /// at most 255 entries.
 pub const MAX_CUSTOM_LEVELS: usize = u8::MAX as usize;
 
-#[cfg(target_arch = "x86_64")]
+// The C header aligns `Vec4f_t` to 16 only when `__SSE__` is defined, which build.rs
+// enables (and mirrors as the `qualetize_sse` cfg) only for x86_64 targets. Key off
+// that cfg rather than the target arch directly so the two stay in lockstep.
+#[cfg(qualetize_sse)]
 #[repr(C, align(16))]
 pub struct Vec4f {
     pub f32: [f32; 4],
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(qualetize_sse))]
 #[repr(C)]
 pub struct Vec4f {
     pub f32: [f32; 4],
@@ -176,28 +179,18 @@ impl QualetizeSettings {
         self.tile_reduce_allow_flip_y = default_tile_reduce_allow_flip();
     }
 
+    /// Identical to [`Self::genesis`] apart from the pixel format and color space;
+    /// expressed as a struct update over it so the two presets can't drift apart on
+    /// the fields they share.
     pub fn gba_nds() -> Self {
         let rgba_depth = "5551".to_string();
+        let custom_levels = default_level_strings_from_depth(&rgba_depth);
         Self {
-            tile_width: 8,
-            tile_height: 8,
-            n_palettes: 1,
-            n_colors: 16,
-            rgba_depth: rgba_depth.clone(),
-            premul_alpha: false,
+            rgba_depth,
             color_space: ColorSpace::YcbcrPsy,
-            dither_mode: DitherMode::Floyd,
-            dither_level: 0.5,
-            tile_passes: 1000,
-            color_passes: 100,
-            col0_is_clear: false,
-            clear_color: ClearColor::default(),
-            tile_reduce_post_enabled: false,
-            tile_reduce_post_threshold: default_tile_reduce_post_threshold(),
-            tile_reduce_allow_flip_x: default_tile_reduce_allow_flip(),
-            tile_reduce_allow_flip_y: default_tile_reduce_allow_flip(),
             use_custom_levels: false,
-            custom_levels: default_level_strings_from_depth(&rgba_depth),
+            custom_levels,
+            ..Self::genesis()
         }
     }
     pub fn gba_nds_full_palettes() -> Self {
@@ -238,6 +231,43 @@ impl QualetizeSettings {
             ..Self::genesis()
         }
     }
+
+    /// Clamp settings loaded from disk into the ranges the UI enforces (see the
+    /// `DragValue`/`Slider` ranges in `src/ui/settings_panel.rs`).
+    ///
+    /// A hand-edited or corrupted `.qset` can otherwise carry values the UI would
+    /// never produce, and those reach the C `Qualetize` library unchecked: a
+    /// `tile_width` of 0 is an integer divide by zero there, and an oversized
+    /// `n_colors * n_palettes` product overruns the output palette buffer.
+    pub fn sanitize(&mut self) {
+        self.tile_width = self.tile_width.clamp(1, 64);
+        self.tile_height = self.tile_height.clamp(1, 64);
+        self.n_colors = self.n_colors.clamp(1, 256);
+        let max_palettes = 256 / self.n_colors;
+        self.n_palettes = self.n_palettes.clamp(1, max_palettes);
+        self.tile_passes = self.tile_passes.clamp(0, 1000);
+        self.color_passes = self.color_passes.clamp(0, 100);
+
+        if !self.dither_level.is_finite() {
+            self.dither_level = 0.5;
+        }
+        self.dither_level = self.dither_level.clamp(0.0, 2.0);
+
+        if !self.tile_reduce_post_threshold.is_finite() || self.tile_reduce_post_threshold < 0.0 {
+            self.tile_reduce_post_threshold = default_tile_reduce_post_threshold();
+        }
+
+        if !is_valid_rgba_depth(&self.rgba_depth) {
+            self.rgba_depth = DEFAULT_RGBA_DEPTH.to_string();
+        }
+    }
+}
+
+/// A valid RGBA depth string is exactly 4 characters, each a digit `1'..='8'`
+/// (bits per channel); anything else can't be turned into a sane [`Vec4f`] depth.
+fn is_valid_rgba_depth(rgba_depth: &str) -> bool {
+    let chars: Vec<char> = rgba_depth.chars().collect();
+    chars.len() == 4 && chars.iter().all(|c| ('1'..='8').contains(c))
 }
 
 impl Default for QualetizeSettings {
@@ -246,16 +276,11 @@ impl Default for QualetizeSettings {
     }
 }
 
+/// A digit `d` in `1..=8` means `d` bits per channel, i.e. `2^d - 1` levels; anything
+/// else (including non-digit characters) falls back to a full 8-bit channel.
 fn char_to_depth(c: char) -> f32 {
-    match c {
-        '1' => 1.0,
-        '2' => 3.0,
-        '3' => 7.0,
-        '4' => 15.0,
-        '5' => 31.0,
-        '6' => 63.0,
-        '7' => 127.0,
-        '8' => 255.0,
+    match c.to_digit(10) {
+        Some(d @ 1..=8) => ((1u32 << d) - 1) as f32,
         _ => 255.0,
     }
 }
@@ -268,14 +293,19 @@ fn default_tile_reduce_allow_flip() -> bool {
     true
 }
 
+/// Parses a 4-character RGBA depth string into per-channel level counts.
+///
+/// Counts *characters*, not bytes: a non-ASCII string can have `len() == 4` in bytes
+/// while holding fewer than 4 `char`s (or vice versa), and indexing a byte-based
+/// `Vec<char>` built from the wrong count used to panic.
 fn parse_rgba_depth(rgba_depth: &str) -> [f32; 4] {
-    if rgba_depth.len() == 4 {
-        let chars: Vec<char> = rgba_depth.chars().collect();
+    let chars: Vec<char> = rgba_depth.chars().collect();
+    if let [a, b, c, d] = chars[..] {
         [
-            char_to_depth(chars[0]),
-            char_to_depth(chars[1]),
-            char_to_depth(chars[2]),
-            char_to_depth(chars[3]),
+            char_to_depth(a),
+            char_to_depth(b),
+            char_to_depth(c),
+            char_to_depth(d),
         ]
     } else {
         [255.0, 255.0, 255.0, 255.0] // Default to 8-bit
@@ -300,7 +330,7 @@ fn levels_to_string(levels: Vec<u8>) -> String {
         .join(",")
 }
 
-pub fn default_level_strings_from_depth(rgba_depth: &str) -> [String; 4] {
+pub(crate) fn default_level_strings_from_depth(rgba_depth: &str) -> [String; 4] {
     let depth = parse_rgba_depth(rgba_depth);
     [
         levels_to_string(depth_to_levels(depth[0])),
@@ -329,7 +359,7 @@ static LEVEL_LIST_RE: LazyLock<Regex> = LazyLock::new(|| {
         .expect("level list regex is valid")
 });
 
-pub fn validate_0_255_array(array_str: &str) -> bool {
+pub(crate) fn validate_0_255_array(array_str: &str) -> bool {
     if array_str.is_empty() {
         return false;
     }
@@ -355,13 +385,22 @@ fn parse_custom_levels(array_str: &str) -> Option<Vec<f32>> {
 }
 
 pub struct QualetizePlanOwned {
-    pub plan: QualetizePlan,
+    // Private: `plan.custom_levels` points into `custom_level_storage` below, so
+    // handing the plan out by value would let it outlive the storage that backs
+    // its pointers. Only borrow it through `as_ptr`.
+    plan: QualetizePlan,
+    // Never read directly: it exists purely to keep the boxed slices `plan`
+    // points into alive for as long as `self` is. Dropping them early would
+    // dangle `plan.custom_levels`.
+    #[allow(dead_code)]
     custom_level_storage: [Option<Box<[f32]>>; 4],
 }
 
 impl QualetizePlanOwned {
+    /// Invariant: `plan.custom_levels` points into the boxed slices held in
+    /// `custom_level_storage`, which live exactly as long as `self`. Callers must
+    /// not use the returned pointer beyond `self`'s lifetime.
     pub fn as_ptr(&self) -> *const QualetizePlan {
-        let _ = &self.custom_level_storage;
         &self.plan
     }
 }
@@ -413,6 +452,87 @@ impl From<QualetizeSettings> for QualetizePlanOwned {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `rgba_depth.len() == 4` used to check bytes, not characters, so a 4-byte
+    /// string that isn't 4 characters (e.g. containing multi-byte UTF-8) would pass
+    /// the length check and then panic indexing a shorter `Vec<char>`.
+    #[test]
+    fn parse_rgba_depth_does_not_panic_on_non_ascii_input() {
+        // "é" is 2 bytes but 1 char: "é331" is 5 bytes / 4 chars, "éé31" is 6 bytes
+        // / 4 chars, and "é31" is 4 bytes / 3 chars. None of these should panic, and
+        // none is a valid 4-digit depth string other than the 4-char ones, which
+        // fall back to the "not a digit" branch of `char_to_depth` for 'é'.
+        assert_eq!(parse_rgba_depth("é31"), [255.0, 255.0, 255.0, 255.0]);
+        assert_eq!(
+            parse_rgba_depth("éé31"),
+            [255.0, 255.0, char_to_depth('3'), char_to_depth('1')]
+        );
+        assert_eq!(parse_rgba_depth("é3331"), [255.0, 255.0, 255.0, 255.0]);
+    }
+
+    /// `char_to_depth`'s formula (`2^d - 1` for a digit `d` in `1..=8`) must agree
+    /// with the explicit table it replaced.
+    #[test]
+    fn char_to_depth_formula_matches_the_old_table() {
+        let old_table = [
+            ('1', 1.0),
+            ('2', 3.0),
+            ('3', 7.0),
+            ('4', 15.0),
+            ('5', 31.0),
+            ('6', 63.0),
+            ('7', 127.0),
+            ('8', 255.0),
+        ];
+        for (c, expected) in old_table {
+            assert_eq!(char_to_depth(c), expected, "digit {c}");
+        }
+        // Out of range or non-digit characters still fall back to 8-bit.
+        assert_eq!(char_to_depth('0'), 255.0);
+        assert_eq!(char_to_depth('9'), 255.0);
+        assert_eq!(char_to_depth('x'), 255.0);
+    }
+
+    /// The C library divides by `tile_width`/`tile_height` and writes
+    /// `n_colors * n_palettes` palette entries, so out-of-range values loaded from a
+    /// hand-edited `.qset` must be clamped rather than passed straight through.
+    #[test]
+    fn sanitize_clamps_out_of_range_values_loaded_from_disk() {
+        let mut settings = QualetizeSettings::genesis();
+        settings.tile_width = 0;
+        settings.tile_height = 1000;
+        settings.n_colors = 0;
+        settings.n_palettes = u16::MAX;
+        settings.tile_passes = u32::MAX;
+        settings.color_passes = u32::MAX;
+        settings.dither_level = f32::NAN;
+        settings.tile_reduce_post_threshold = -5.0;
+        settings.rgba_depth = "9a3!".to_string();
+
+        settings.sanitize();
+
+        assert!((1..=64).contains(&settings.tile_width));
+        assert!((1..=64).contains(&settings.tile_height));
+        assert!((1..=256).contains(&settings.n_colors));
+        assert!(settings.n_colors as u32 * settings.n_palettes as u32 <= 256);
+        assert!(settings.tile_passes <= 1000);
+        assert!(settings.color_passes <= 100);
+        assert_eq!(settings.dither_level, 0.5);
+        assert!(settings.tile_reduce_post_threshold >= 0.0);
+        assert_eq!(settings.rgba_depth, DEFAULT_RGBA_DEPTH);
+    }
+
+    /// A well-formed settings struct (e.g. any preset) must survive `sanitize`
+    /// unchanged.
+    #[test]
+    fn sanitize_leaves_in_range_values_alone() {
+        let mut settings = QualetizeSettings::genesis();
+        let before = settings.clone();
+
+        settings.sanitize();
+
+        assert_eq!(settings, before);
+    }
 
     #[test]
     fn validate_0_255_array_accepts_well_formed_lists() {

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,4 +1,5 @@
 use super::styles;
+use super::widgets;
 use crate::types::{
     AppState, ExportFormat,
     app_state::{AppStateRequest, ExportSource},
@@ -65,18 +66,13 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
         });
 
         // Format selection ComboBox
-        egui::ComboBox::from_id_salt("export_format_footer")
-            .selected_text(state.preferences.selected_export_format.display_name())
-            .width(64.0)
-            .show_ui(ui, |ui| {
-                for format in ExportFormat::indexed_list() {
-                    ui.selectable_value(
-                        &mut state.preferences.selected_export_format,
-                        *format,
-                        format.display_name(),
-                    );
-                }
-            });
+        widgets::EnumCombo::new(
+            "export_format_footer",
+            ExportFormat::indexed_list(),
+            ExportFormat::display_name,
+        )
+        .width(64.0)
+        .show(ui, &mut state.preferences.selected_export_format);
         let count_label = match state.reduced_tile_count {
             Some(count) => format!("Tiles: {count}"),
             None => "Tiles: --".to_string(),
@@ -84,36 +80,27 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
         ui.menu_button(egui::RichText::new(count_label).strong(), |ui| {
             let mut options_changed = false;
 
-            if ui
-                .checkbox(
+            for (value, label) in [
+                (
                     &mut state.tile_count.settings.allow_flip_x,
                     "Allowed X Flips",
-                )
-                .clicked()
-            {
-                options_changed = true;
-            }
-            if ui
-                .checkbox(
+                ),
+                (
                     &mut state.tile_count.settings.allow_flip_y,
                     "Allowed Y Flips",
-                )
-                .clicked()
-            {
-                options_changed = true;
+                ),
+            ] {
+                options_changed |= ui.checkbox(value, label).changed();
             }
 
             ui.separator();
 
-            if ui
+            options_changed |= ui
                 .checkbox(
                     &mut state.tile_count.settings.visible_only,
                     "Ignore fully transparent tiles",
                 )
-                .clicked()
-            {
-                options_changed = true;
-            }
+                .changed();
 
             if options_changed {
                 state.tile_count.mark_dirty();
@@ -123,8 +110,8 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
 }
 
 fn apply_export_button_style(ui: &mut egui::Ui) {
-    ui.style_mut().spacing.button_padding = egui::vec2(10.0, 4.0);
-    let style = &mut ui.style_mut();
+    let style = ui.style_mut();
+    style.spacing.button_padding = egui::vec2(10.0, 4.0);
 
     // Inactive state
     style.visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0_f32, Color32::WHITE);

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -2,7 +2,6 @@ use super::styles;
 use crate::types::{
     AppState, ExportFormat,
     app_state::{AppStateRequest, ExportSource},
-    image::ImageData,
 };
 use egui::{Color32, Vec2};
 
@@ -78,8 +77,7 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
                     );
                 }
             });
-        let _ = compute_tile_count(state);
-        let count_label = match state.tile_count.last_count {
+        let count_label = match state.reduced_tile_count {
             Some(count) => format!("Tiles: {count}"),
             None => "Tiles: --".to_string(),
         };
@@ -119,33 +117,9 @@ fn draw_export_controls(ui: &mut egui::Ui, state: &mut AppState) {
 
             if options_changed {
                 state.tile_count.mark_dirty();
-                let _ = compute_tile_count(state);
             }
         });
     });
-}
-
-fn compute_tile_count(state: &mut AppState) -> Option<usize> {
-    let Some(output_image) = &state.output_image else {
-        return None;
-    };
-    let Some(indexed) = &output_image.indexed else {
-        return None;
-    };
-
-    if state.tile_count.dirty || state.tile_count.last_count.is_none() {
-        state.tile_count.last_count = ImageData::count_unique_tiles(
-            indexed,
-            output_image.width,
-            output_image.height,
-            state.settings.tile_width,
-            state.settings.tile_height,
-            state.tile_count.options(),
-        );
-        state.tile_count.dirty = false;
-    }
-
-    state.tile_count.last_count
 }
 
 fn apply_export_button_style(ui: &mut egui::Ui) {

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -101,10 +101,12 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
             ui.menu_button("Reset Color Correction", |ui| {
                 for preset in ColorCorrectionPreset::all() {
                     if ui.button(preset.display_name()).clicked() {
+                        // Edits `state.color_correction`, not `state.settings`;
+                        // app.rs detects that change itself, so this does not
+                        // need to request a re-quantization.
                         state
                             .color_correction
                             .apply_preset(preset.color_correction());
-                        settings_changed = true;
                         ui.close();
                     }
                 }
@@ -144,25 +146,12 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
                 ui.separator();
 
                 ui.menu_button("Zoom", |ui| {
-                    if ui.button("Zoom 1x").clicked() {
-                        state.zoom = 1.0;
-                        state.pan_offset = egui::Vec2::ZERO;
-                        ui.close();
-                    }
-                    if ui.button("Zoom 2x").clicked() {
-                        state.zoom = 2.0;
-                        state.pan_offset = egui::Vec2::ZERO;
-                        ui.close();
-                    }
-                    if ui.button("Zoom 4x").clicked() {
-                        state.zoom = 4.0;
-                        state.pan_offset = egui::Vec2::ZERO;
-                        ui.close();
-                    }
-                    if ui.button("Zoom 8x").clicked() {
-                        state.zoom = 8.0;
-                        state.pan_offset = egui::Vec2::ZERO;
-                        ui.close();
+                    for z in [1.0, 2.0, 4.0, 8.0] {
+                        if ui.button(format!("Zoom {}x", z as i32)).clicked() {
+                            state.zoom = z;
+                            state.pan_offset = egui::Vec2::ZERO;
+                            ui.close();
+                        }
                     }
                 });
 
@@ -178,7 +167,7 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
     });
 
     let mut show_dialog = state.preferences.show_appearance;
-    if egui::Window::new("Appearance")
+    egui::Window::new("Appearance")
         .open(&mut show_dialog)
         .resizable(false)
         .collapsible(false)
@@ -250,11 +239,8 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
                     state.reset_view_settings();
                 }
             });
-        })
-        .is_some()
-    {
-        state.preferences.show_appearance = show_dialog;
-    }
+        });
+    state.preferences.show_appearance = show_dialog;
 
     (settings_changed, tile_reduce_changed)
 }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -135,10 +135,6 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside),
             )
             .ui(ui, |ui| {
-                ui.label(egui::widget_text::RichText::new("Settings").small());
-                ui.checkbox(&mut state.preferences.show_advanced, "Advanced Settings");
-
-                ui.separator();
                 ui.label(egui::widget_text::RichText::new("Canvas").small());
                 ui.checkbox(&mut state.preferences.show_palettes, "Palettes");
 

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -137,7 +137,6 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
             .ui(ui, |ui| {
                 ui.label(egui::widget_text::RichText::new("Settings").small());
                 ui.checkbox(&mut state.preferences.show_advanced, "Advanced Settings");
-                ui.checkbox(&mut state.preferences.show_debug_info, "Debug Info");
 
                 ui.separator();
                 ui.label(egui::widget_text::RichText::new("Canvas").small());

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -5,19 +5,33 @@ use egui::{Align2, Color32, FontId, Id, Pos2, Rect, Vec2};
 /// Gap between the image panels.
 const PANEL_MARGIN: f32 = 4.0;
 
+/// Zoom, pan, and background shared by every panel drawn in a frame, so each
+/// [`ImagePanel`] literal only needs to name what actually differs between
+/// panels.
+struct ViewParams {
+    zoom: f32,
+    pan_offset: Vec2,
+    background: Color32,
+}
+
+/// Fields an [`ImagePanel`] usually leaves at their default: most panels have
+/// no spinner, overlay text, notice, or palette overlay.
+#[derive(Default)]
+struct PanelExtras<'a> {
+    has_spinner: bool,
+    overlay_text: Option<&'a str>,
+    /// Persistent warning drawn in the top left corner of the panel.
+    notice: Option<&'a str>,
+    palettes: Option<&'a [Vec<Color32>]>,
+}
+
 /// Everything one image panel needs to draw itself.
 struct ImagePanel<'a> {
     title: &'a str,
     image: Option<&'a ImageData>,
     size: Vec2,
-    zoom: f32,
-    pan_offset: Vec2,
-    background: Color32,
-    has_spinner: bool,
-    overlay_text: Option<&'a str>,
-    /// Persistent warning drawn in the top left corner of the panel.
-    notice: Option<&'a str>,
-    palettes: Option<&'a Vec<Vec<Color32>>>,
+    view: &'a ViewParams,
+    extras: PanelExtras<'a>,
 }
 
 pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_processing: bool) {
@@ -30,12 +44,14 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
     // panels share the same dimensions at a given zoom.
     let original_image = state.processing_input();
 
-    let zoom = state.zoom;
-    let pan_offset = state.pan_offset;
-    let background = state
-        .preferences
-        .background_color
-        .unwrap_or(Color32::from_gray(64));
+    let view = ViewParams {
+        zoom: state.zoom,
+        pan_offset: state.pan_offset,
+        background: state
+            .preferences
+            .background_color
+            .unwrap_or(Color32::from_gray(64)),
+    };
     let mut pan_changed = Vec2::ZERO;
 
     // Left column holds the inputs, right column the outputs. The optional
@@ -45,17 +61,15 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
 
     // The palette is identical for both output panels, so it is only drawn on
     // the Qualetized one to keep its position stable.
-    let palettes = state
-        .preferences
-        .show_palettes
-        .then(|| {
-            state
-                .output_palette_sorted_indexed_image
-                .as_ref()
-                .or_else(|| state.output_image.as_ref().and_then(|i| i.indexed.as_ref()))
-                .map(|indexed| &indexed.palettes_for_ui)
-        })
-        .flatten();
+    let palettes: Option<&[Vec<Color32>]> = if state.preferences.show_palettes {
+        state
+            .output_palette_sorted_indexed_image
+            .as_ref()
+            .or_else(|| state.output_image.as_ref().and_then(|i| i.indexed.as_ref()))
+            .map(|indexed| indexed.palettes_for_ui.as_slice())
+    } else {
+        None
+    };
 
     let column_width = (available_size.x - PANEL_MARGIN) / 2.0;
     let input_height = column_height(available_size.y, 1 + usize::from(show_color_corrected));
@@ -74,13 +88,12 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                     title: "Original",
                     image: original_image,
                     size: Vec2::new(column_width, input_height),
-                    zoom,
-                    pan_offset,
-                    background,
-                    has_spinner: false,
-                    overlay_text: fit_toast.as_deref(),
-                    notice: fit_notice.as_deref(),
-                    palettes: None,
+                    view: &view,
+                    extras: PanelExtras {
+                        overlay_text: fit_toast.as_deref(),
+                        notice: fit_notice.as_deref(),
+                        ..Default::default()
+                    },
                 },
                 &mut pan_changed,
             );
@@ -92,13 +105,11 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                         title: "Color Corrected",
                         image: state.color_corrected_image.as_ref(),
                         size: Vec2::new(column_width, input_height),
-                        zoom,
-                        pan_offset,
-                        background,
-                        has_spinner: state.color_corrected_image.is_none(),
-                        overlay_text: None,
-                        notice: None,
-                        palettes: None,
+                        view: &view,
+                        extras: PanelExtras {
+                            has_spinner: state.color_corrected_image.is_none(),
+                            ..Default::default()
+                        },
                     },
                     &mut pan_changed,
                 );
@@ -115,13 +126,12 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                     title: "Qualetized",
                     image: state.base_output_image.as_ref(),
                     size: Vec2::new(column_width, output_height),
-                    zoom,
-                    pan_offset,
-                    background,
-                    has_spinner: qualetize_processing,
-                    overlay_text: None,
-                    notice: None,
-                    palettes,
+                    view: &view,
+                    extras: PanelExtras {
+                        has_spinner: qualetize_processing,
+                        palettes,
+                        ..Default::default()
+                    },
                 },
                 &mut pan_changed,
             );
@@ -133,14 +143,13 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                         title: "Tile Reduced",
                         image: state.output_image.as_ref(),
                         size: Vec2::new(column_width, output_height),
-                        zoom,
-                        pan_offset,
-                        background,
-                        // A new quantization invalidates the reduced result too.
-                        has_spinner: qualetize_processing || state.tile_reduce_processing,
-                        overlay_text: toast.as_deref(),
-                        notice: None,
-                        palettes: None,
+                        view: &view,
+                        extras: PanelExtras {
+                            // A new quantization invalidates the reduced result too.
+                            has_spinner: qualetize_processing || state.tile_reduce_processing,
+                            overlay_text: toast.as_deref(),
+                            ..Default::default()
+                        },
                     },
                     &mut pan_changed,
                 );
@@ -202,21 +211,21 @@ fn draw_background_and_pixels(painter: &egui::Painter, canvas: Rect, base_color:
         base_color.a(),
     );
 
-    for yi in 0.. {
-        let y = (yi as f32 + 0.5) * MAGNIFICATION_PIXEL_SIZE;
-        if y > canvas.height() + MAGNIFICATION_PIXEL_SIZE {
-            break;
-        }
-        for xi in 0.. {
-            let x = (xi as f32 + 0.5) * MAGNIFICATION_PIXEL_SIZE;
-            if x > canvas.width() + MAGNIFICATION_PIXEL_SIZE {
-                break;
-            }
+    // `canvas.center() + vec2(-w/2, -h/2)` is just `canvas.min`; the dot grid
+    // is anchored there, offset back by the canvas's own phase within one dot
+    // cell so the grid appears to pan continuously under `canvas`.
+    let origin = canvas.min - egui::vec2(canvas_min_x, canvas_min_y);
+    let nx = (canvas.width() / MAGNIFICATION_PIXEL_SIZE).ceil() as i32 + 1;
+    let ny = (canvas.height() / MAGNIFICATION_PIXEL_SIZE).ceil() as i32 + 1;
+
+    for yi in 0..ny {
+        for xi in 0..nx {
             painter.circle_filled(
-                canvas.center()
-                    + egui::vec2(x, y)
-                    + egui::vec2(-canvas_min_x, -canvas_min_y)
-                    + egui::vec2(-canvas.width() / 2.0, -canvas.height() / 2.0),
+                origin
+                    + egui::vec2(
+                        (xi as f32 + 0.5) * MAGNIFICATION_PIXEL_SIZE,
+                        (yi as f32 + 0.5) * MAGNIFICATION_PIXEL_SIZE,
+                    ),
                 pixel_radius,
                 pixel_color,
             );
@@ -272,8 +281,9 @@ fn draw_title(painter: &egui::Painter, canvas: Rect, title: &str, ui_ctx: &egui:
         return;
     }
 
-    let visuals = ui_ctx.global_style().visuals.clone();
-    let text_color = visuals.override_text_color.unwrap_or(visuals.text_color());
+    // `text_color()` already honors `override_text_color`, so there is no need
+    // to clone `Visuals` just to read it back off.
+    let text_color = ui_ctx.global_style().visuals.text_color();
     let pos = canvas.left_bottom() + Vec2::new(4.0, -20.0);
     draw_label_chip(painter, ui_ctx, pos, title, text_color);
 }
@@ -327,20 +337,26 @@ fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2
                 ui.allocate_painter(panel.size, egui::Sense::click_and_drag());
             let canvas = response.rect;
 
-            draw_background_and_pixels(&painter, canvas, panel.background);
-            draw_main_image(&painter, canvas, panel.image, panel.zoom, panel.pan_offset);
+            draw_background_and_pixels(&painter, canvas, panel.view.background);
+            draw_main_image(
+                &painter,
+                canvas,
+                panel.image,
+                panel.view.zoom,
+                panel.view.pan_offset,
+            );
             draw_title(&painter, canvas, panel.title, ui.ctx());
-            if let Some(notice) = panel.notice {
+            if let Some(notice) = panel.extras.notice {
                 draw_notice(&painter, canvas, notice, ui.ctx());
             }
 
-            if let Some(palettes) = panel.palettes {
+            if let Some(palettes) = panel.extras.palettes {
                 draw_palettes_overlay(&painter, canvas, palettes);
             }
-            if panel.has_spinner {
+            if panel.extras.has_spinner {
                 draw_spinner(&painter, canvas, ui.ctx());
             }
-            if let Some(text) = panel.overlay_text {
+            if let Some(text) = panel.extras.overlay_text {
                 draw_overlay_text(&painter, canvas, ui.ctx(), text);
             }
 
@@ -363,6 +379,15 @@ fn calculate_image_rect(
     Rect::from_center_size(view_center, display_size)
 }
 
+/// Rect of one swatch in a palette row: `idx` within a palette of
+/// `palette_len` colors, growing leftwards from `origin` (the row's right
+/// edge, at its top).
+fn swatch_rect(origin: Pos2, palette_len: usize, idx: usize, size: f32, spacing: f32) -> Rect {
+    let width = (palette_len as f32) * (size + spacing) - spacing;
+    let x = origin.x - width + (idx as f32) * (size + spacing);
+    Rect::from_min_size(Pos2::new(x, origin.y), Vec2::new(size, size))
+}
+
 fn draw_palettes_overlay(painter: &egui::Painter, rect: Rect, palettes: &[Vec<egui::Color32>]) {
     if palettes.is_empty() {
         return;
@@ -371,7 +396,6 @@ fn draw_palettes_overlay(painter: &egui::Painter, rect: Rect, palettes: &[Vec<eg
     let ctx = painter.ctx();
     let pointer_pos = ctx.pointer_hover_pos();
     let mut hovered: Option<(usize, usize)> = None;
-    let mut hovered_color: Option<egui::Color32> = None;
 
     let palette_margin = 8.0;
     let palette_spacing = 1.0;
@@ -383,18 +407,16 @@ fn draw_palettes_overlay(painter: &egui::Painter, rect: Rect, palettes: &[Vec<eg
     if let Some(pos) = pointer_pos {
         let mut hover_y = current_y;
         'outer: for (palette_idx, palette) in palettes.iter().enumerate() {
-            let palette_width =
-                (palette.len() as f32) * (palette_size + palette_spacing) - palette_spacing;
-            for (color_idx, &color) in palette.iter().enumerate() {
-                let x =
-                    start_x - palette_width + (color_idx as f32) * (palette_size + palette_spacing);
-                let color_rect = Rect::from_min_size(
-                    Pos2::new(x, hover_y),
-                    Vec2::new(palette_size, palette_size),
+            for (color_idx, _) in palette.iter().enumerate() {
+                let color_rect = swatch_rect(
+                    Pos2::new(start_x, hover_y),
+                    palette.len(),
+                    color_idx,
+                    palette_size,
+                    palette_spacing,
                 );
                 if color_rect.contains(pos) {
                     hovered = Some((palette_idx, color_idx));
-                    hovered_color = Some(color);
                     break 'outer;
                 }
             }
@@ -417,9 +439,8 @@ fn draw_palettes_overlay(painter: &egui::Painter, rect: Rect, palettes: &[Vec<eg
         current_y += palette_size + palette_spacing;
     }
 
-    if let Some((palette_idx, color_idx)) = hovered
-        && let Some(color) = hovered_color
-    {
+    if let Some((palette_idx, color_idx)) = hovered {
+        let color = palettes[palette_idx][color_idx];
         let hex = if color.a() == 255 {
             format!("#{:02X}{:02X}{:02X}", color.r(), color.g(), color.b())
         } else {
@@ -460,22 +481,28 @@ fn draw_palettes_overlay(painter: &egui::Painter, rect: Rect, palettes: &[Vec<eg
     }
 }
 
+/// Size of one palette swatch: bounded so a full row fits the panel's width
+/// and, since palettes stack vertically, so all `palettes.len()` rows fit its
+/// height too.
 fn calculate_palette_size(
     rect: &Rect,
     palettes: &[Vec<egui::Color32>],
     palette_margin: f32,
     palette_spacing: f32,
 ) -> f32 {
-    if let Some(first_palette) = palettes.first() {
-        4.0_f32.max(16.0_f32.min(
-            (rect.width()
-                - palette_margin * 2.0
-                - ((first_palette.len() as f32) - 1.0) * palette_spacing)
-                / (first_palette.len() as f32),
-        ))
-    } else {
-        8.0
-    }
+    let Some(first_palette) = palettes.first() else {
+        return 8.0;
+    };
+
+    let by_width = (rect.width()
+        - palette_margin * 2.0
+        - ((first_palette.len() as f32) - 1.0) * palette_spacing)
+        / (first_palette.len() as f32);
+
+    let by_height =
+        (rect.height() - palette_margin * 2.0) / (palettes.len() as f32) - palette_spacing;
+
+    4.0_f32.max(16.0_f32.min(by_width.min(by_height)))
 }
 
 fn draw_single_palette(
@@ -487,14 +514,15 @@ fn draw_single_palette(
     palette_spacing: f32,
     hovered: Option<(usize, usize)>,
 ) {
-    let palette_width = (palette.len() as f32) * (palette_size + palette_spacing) - palette_spacing;
     let highlight_color = painter.ctx().global_style().visuals.selection.stroke.color;
 
     for (color_idx, &color) in palette.iter().enumerate() {
-        let x = origin.x - palette_width + (color_idx as f32) * (palette_size + palette_spacing);
-        let color_rect = Rect::from_min_size(
-            Pos2::new(x, origin.y),
-            Vec2::new(palette_size, palette_size),
+        let color_rect = swatch_rect(
+            origin,
+            palette.len(),
+            color_idx,
+            palette_size,
+            palette_spacing,
         );
 
         painter.rect_filled(color_rect, 0.0, color);
@@ -543,5 +571,18 @@ mod tests {
                 "{panel_count} panels: {used}"
             );
         }
+    }
+
+    #[test]
+    fn palette_size_shrinks_to_fit_many_rows_in_a_short_panel() {
+        let rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(200.0, 60.0));
+        let palettes: Vec<Vec<Color32>> = (0..16).map(|_| vec![Color32::BLACK; 4]).collect();
+        let size = calculate_palette_size(&rect, &palettes, 8.0, 1.0);
+        // 16 rows in 60px tall (minus margins) leaves well under 16px per row.
+        assert!(size < 16.0, "expected a shrunk size, got {size}");
+        assert!(
+            size >= 4.0,
+            "size should not go below the minimum, got {size}"
+        );
     }
 }

--- a/src/ui/image_viewer.rs
+++ b/src/ui/image_viewer.rs
@@ -52,7 +52,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
             .background_color
             .unwrap_or(Color32::from_gray(64)),
     };
-    let mut pan_changed = Vec2::ZERO;
+    let mut view_change = ViewChange::default();
 
     // Left column holds the inputs, right column the outputs. The optional
     // panels appear exactly when their pass is enabled.
@@ -95,7 +95,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                         ..Default::default()
                     },
                 },
-                &mut pan_changed,
+                &mut view_change,
             );
 
             if show_color_corrected {
@@ -111,7 +111,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                             ..Default::default()
                         },
                     },
-                    &mut pan_changed,
+                    &mut view_change,
                 );
             }
         });
@@ -133,7 +133,7 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                         ..Default::default()
                     },
                 },
-                &mut pan_changed,
+                &mut view_change,
             );
 
             if show_tile_reduced {
@@ -151,23 +151,44 @@ pub fn draw_image_view(ui: &mut egui::Ui, state: &mut AppState, qualetize_proces
                             ..Default::default()
                         },
                     },
-                    &mut pan_changed,
+                    &mut view_change,
                 );
             }
         });
     });
 
-    if pan_changed != Vec2::ZERO {
-        state.pan_offset += pan_changed;
+    state.pan_offset += view_change.pan;
+    if let Some(zoom) = view_change.zoom {
+        state.zoom = zoom;
     }
+}
 
-    if ui.ui_contains_pointer() {
-        let scroll_delta = ui.ctx().input(|i| i.smooth_scroll_delta.y);
-        if scroll_delta != 0.0 {
-            let zoom_factor = 1.0 + scroll_delta * 0.001;
-            state.zoom = (state.zoom * zoom_factor).clamp(0.1, 20.0);
-        }
-    }
+/// What the panels asked to change about the shared view this frame:
+/// drags accumulate into `pan`, a scroll over a panel sets `zoom` and adds
+/// the pan that keeps the pixel under the cursor in place.
+#[derive(Default)]
+struct ViewChange {
+    pan: Vec2,
+    zoom: Option<f32>,
+}
+
+const MIN_ZOOM: f32 = 0.1;
+const MAX_ZOOM: f32 = 20.0;
+
+/// Zoom in or out around `cursor`, which is given relative to the image's
+/// current center on screen. Returns the new zoom and the pan adjustment
+/// that keeps the image point under the cursor where it is.
+///
+/// The factor is exponential in the scroll distance so scrolling up and
+/// then down by the same amount lands back on the same zoom, and a large
+/// downward scroll can never flip the factor negative.
+fn zoom_about(zoom: f32, scroll_delta: f32, cursor: Vec2) -> (f32, Vec2) {
+    let new_zoom = (zoom * (scroll_delta * 0.001).exp()).clamp(MIN_ZOOM, MAX_ZOOM);
+    // The point under the cursor is `cursor / zoom` image pixels from the
+    // center; after zooming it would sit at `cursor * new_zoom / zoom`, so
+    // the center has to move by the difference.
+    let pan = cursor * (1.0 - new_zoom / zoom);
+    (new_zoom, pan)
 }
 
 /// Height of one panel in a column of `panel_count` stacked panels.
@@ -328,7 +349,7 @@ fn draw_overlay_text(painter: &egui::Painter, canvas: Rect, ui_ctx: &egui::Conte
     painter.galley(rect.center() - galley.size() * 0.5, galley, text_color);
 }
 
-fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2) {
+fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, view_change: &mut ViewChange) {
     ui.allocate_ui_with_layout(
         panel.size,
         egui::Layout::top_down(egui::Align::Center),
@@ -362,7 +383,19 @@ fn draw_image_panel(ui: &mut egui::Ui, panel: ImagePanel, pan_changed: &mut Vec2
 
             // Panning
             if response.dragged() {
-                *pan_changed += response.drag_delta();
+                view_change.pan += response.drag_delta();
+            }
+
+            // Zooming, anchored on the pixel under the cursor
+            if let Some(cursor) = response.hover_pos() {
+                let scroll_delta = ui.ctx().input(|i| i.smooth_scroll_delta.y);
+                if scroll_delta != 0.0 {
+                    let image_center = canvas.center() + panel.view.pan_offset;
+                    let (zoom, pan) =
+                        zoom_about(panel.view.zoom, scroll_delta, cursor - image_center);
+                    view_change.zoom = Some(zoom);
+                    view_change.pan += pan;
+                }
             }
         },
     );
@@ -571,6 +604,35 @@ mod tests {
                 "{panel_count} panels: {used}"
             );
         }
+    }
+
+    /// The image point under the cursor must not move when zooming: its
+    /// screen offset from the image center scales with the zoom, and the pan
+    /// has to cancel that exactly.
+    #[test]
+    fn zooming_keeps_the_pixel_under_the_cursor_in_place() {
+        let cursor = Vec2::new(120.0, -40.0);
+        for (zoom, scroll) in [(1.0, 500.0), (4.0, -800.0), (0.5, 1000.0)] {
+            let (new_zoom, pan) = zoom_about(zoom, scroll, cursor);
+            let image_point = cursor / zoom;
+            let after = pan + image_point * new_zoom;
+            assert!(
+                (after - cursor).length() < 1e-3,
+                "zoom {zoom} scroll {scroll}"
+            );
+        }
+    }
+
+    #[test]
+    fn zoom_is_symmetric_and_clamped() {
+        let (up, _) = zoom_about(1.0, 700.0, Vec2::ZERO);
+        let (back, _) = zoom_about(up, -700.0, Vec2::ZERO);
+        assert!((back - 1.0).abs() < 1e-5);
+
+        let (floor, _) = zoom_about(0.2, -100_000.0, Vec2::ZERO);
+        assert_eq!(floor, MIN_ZOOM);
+        let (ceiling, _) = zoom_about(10.0, 100_000.0, Vec2::ZERO);
+        assert_eq!(ceiling, MAX_ZOOM);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ mod header;
 mod image_viewer;
 mod settings_panel;
 pub mod styles;
+mod widgets;
 
 pub use footer::draw_footer;
 pub use header::draw_header;

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -1,11 +1,12 @@
 use super::styles::{UiMarginExt, error_color, warning_color};
+use super::widgets;
 use crate::color_processor::{
     display_value_to_gamma, format_gamma, format_percentage, gamma_to_display_value,
 };
 use crate::types::qualetize::validate_0_255_array;
 use crate::types::{
     AppState, ClearColor, ColorSpace, DitherMode,
-    color_correction::ColorCorrection,
+    color_correction::ColorCorrectionPreset,
     image::{SortMode, SortOrder},
 };
 use std::ops::RangeInclusive;
@@ -40,8 +41,10 @@ pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bo
         ui.separator();
     }
 
-    // Color correction settings
-    settings_changed |= draw_color_correction_settings(ui, state);
+    // Color correction settings. These edit `state.color_correction`, not
+    // `state.settings`, and app.rs already detects those changes itself, so
+    // this does not feed into `settings_changed`.
+    draw_color_correction_settings(ui, state);
     ui.separator();
 
     tile_reduce_changed |= draw_tile_reduce_settings(ui, state);
@@ -111,13 +114,14 @@ fn draw_advanced_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     settings_changed |= draw_clustering_settings(ui, state);
 
     ui.separator();
-    if ui
-        .checkbox(&mut state.settings.premul_alpha, "Premultiplied Alpha")
-        .on_hover_text("Alpha is pre-multiplied (y/n)\nWhile most formats generally pre-multiply the colors by the alpha value,\n32-bit BMP files generally do not.\nNote that if this option is set, then output colors in the palette will also be pre-multiplied.")
-        .changed()
-    {
-        settings_changed = true;
-    }
+    settings_changed |= widgets::checkbox(
+        ui,
+        &mut state.settings.premul_alpha,
+        "Premultiplied Alpha",
+        Some(
+            "Alpha is pre-multiplied (y/n)\nWhile most formats generally pre-multiply the colors by the alpha value,\n32-bit BMP files generally do not.\nNote that if this option is set, then output colors in the palette will also be pre-multiplied.",
+        ),
+    );
 
     settings_changed
 }
@@ -136,29 +140,27 @@ fn draw_basic_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         // Limit max colors based on palette count
         let max_colors = 256 / state.settings.n_palettes.max(1);
 
-        if ui
-            .add(egui::DragValue::new(&mut state.settings.n_palettes).range(1..=max_palettes))
-            .on_hover_text("Number of palettes available")
-            .changed()
-        {
-            settings_changed = true;
-        }
+        settings_changed |= widgets::drag_u16(
+            ui,
+            &mut state.settings.n_palettes,
+            1..=max_palettes,
+            "Number of palettes available",
+        );
 
         ui.label("*");
 
         ui.label("Colors:")
             .on_hover_text("Set number of colors per palette\nNote that this value times the number of palettes must be less than or equal to 256.");
 
-        if ui
-            .add(egui::DragValue::new(&mut state.settings.n_colors).range(1..=max_colors))
-            .on_hover_text("Number of colors per palette")
-            .changed()
-        {
-            settings_changed = true;
-        }
+        settings_changed |= widgets::drag_u16(
+            ui,
+            &mut state.settings.n_colors,
+            1..=max_colors,
+            "Number of colors per palette",
+        );
 
         ui.label("=");
-        ui.label(egui::RichText::new(format!("{}", state.settings.n_colors * state.settings.n_palettes))
+        ui.label(egui::RichText::new(format!("{}", state.settings.n_colors as u32 * state.settings.n_palettes as u32))
           .strong()).on_hover_text("Palettes * Colors per palette must be <= 256");
         ui.label("(max: 256)");
     });
@@ -192,7 +194,9 @@ fn draw_custom_level_inputs(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             response = response.on_hover_text(
                 "Comma-separated integers between 0 and 255 (e.g., 0,49,87,119,146,174,206,255)",
             );
-            settings_changed |= response.changed();
+            // Invalid text is still being edited, so it must not trigger a
+            // re-quantization: the C library would silently drop the channel.
+            settings_changed |= response.changed() && is_valid;
 
             if !is_valid {
                 ui.label(egui::RichText::new("⚠").color(warning_color(ui.visuals())))
@@ -216,18 +220,12 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         egui::ComboBox::from_id_salt("quant_mode")
             .selected_text(if mode_is_custom { "Custom" } else { "Linear" })
             .show_ui(ui, |ui| {
-                if ui
+                settings_changed |= ui
                     .selectable_value(&mut mode_is_custom, false, "Linear")
-                    .clicked()
-                {
-                    settings_changed = true;
-                }
-                if ui
+                    .changed();
+                settings_changed |= ui
                     .selectable_value(&mut mode_is_custom, true, "Custom")
-                    .clicked()
-                {
-                    settings_changed = true;
-                }
+                    .changed();
             })
             .response
             .on_hover_text("Choose Linear (bit depth) or Custom per-channel levels");
@@ -260,9 +258,9 @@ fn draw_depth_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             "RGBA bit depth (e.g., 8888, 5551, 3331)\nR: 1-8, G: 1-8, B: 1-8, A: 1-8",
         );
 
-        if response.changed() {
-            settings_changed = true;
-        }
+        // Invalid text is still being edited, so it must not trigger a
+        // re-quantization: the C library would silently drop a channel.
+        settings_changed |= response.changed() && error.is_none();
 
         if let Some(error) = error {
             ui.label(egui::RichText::new("⚠").color(warning_color(ui.visuals())))
@@ -279,40 +277,30 @@ fn draw_tile_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     ui.horizontal(|ui| {
         ui.label("Tile Width:")
             .on_hover_text("Set tile width for processing");
-        if ui
-            .add(egui::DragValue::new(&mut state.settings.tile_width).range(1..=64))
-            .on_hover_text("Width of processing tiles")
-            .changed()
-        {
-            settings_changed = true;
-        }
+        settings_changed |= widgets::drag_u16(
+            ui,
+            &mut state.settings.tile_width,
+            1..=64,
+            "Width of processing tiles",
+        );
         ui.label("Height:")
             .on_hover_text("Set tile height for processing");
-        if ui
-            .add(egui::DragValue::new(&mut state.settings.tile_height).range(1..=64))
-            .on_hover_text("Height of processing tiles")
-            .changed()
-        {
-            settings_changed = true;
-        }
+        settings_changed |= widgets::drag_u16(
+            ui,
+            &mut state.settings.tile_height,
+            1..=64,
+            "Height of processing tiles",
+        );
     });
 
     ui.horizontal(|ui| {
         ui.label("Quick presets:");
-        if ui.small_button("8x8").clicked() {
-            state.settings.tile_width = 8;
-            state.settings.tile_height = 8;
-            settings_changed = true;
-        }
-        if ui.small_button("16x16").clicked() {
-            state.settings.tile_width = 16;
-            state.settings.tile_height = 16;
-            settings_changed = true;
-        }
-        if ui.small_button("32x32").clicked() {
-            state.settings.tile_width = 32;
-            state.settings.tile_height = 32;
-            settings_changed = true;
+        for n in [8u16, 16, 32] {
+            if ui.small_button(format!("{n}x{n}")).clicked() {
+                state.settings.tile_width = n;
+                state.settings.tile_height = n;
+                settings_changed = true;
+            }
         }
     });
 
@@ -320,61 +308,32 @@ fn draw_tile_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
 }
 
 fn draw_color_space_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
-    let mut settings_changed = false;
-
     ui.subheading_with_margin("Color Space");
-    egui::ComboBox::from_id_salt("color_space")
-        .selected_text(state.settings.color_space.display_name())
-        .show_ui(ui, |ui| {
-            for color_space in ColorSpace::all() {
-                if ui
-                    .selectable_value(&mut state.settings.color_space, *color_space, color_space.display_name())
-                    .on_hover_text(color_space.description())
-                    .clicked()
-                {
-                    settings_changed = true;
-                }
-            }
-        })
-        .response
-        .on_hover_text("Set colorspace\nDifferent colorspaces may give better/worse results depending on the input image,\nand it may be necessary to experiment to find the optimal one.");
-
-    settings_changed
+    widgets::EnumCombo::new("color_space", ColorSpace::all(), ColorSpace::display_name)
+        .description(ColorSpace::description)
+        .hover("Set colorspace\nDifferent colorspaces may give better/worse results depending on the input image,\nand it may be necessary to experiment to find the optimal one.")
+        .show(ui, &mut state.settings.color_space)
 }
 
 fn draw_dithering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
 
     ui.subheading_with_margin("Dithering");
-    egui::ComboBox::from_id_salt("dithering_mode")
-        .selected_text(state.settings.dither_mode.display_name())
-        .show_ui(ui, |ui| {
-            for dither_mode in DitherMode::all() {
-                if ui
-                    .selectable_value(&mut state.settings.dither_mode, *dither_mode, dither_mode.display_name())
-                    .on_hover_text(dither_mode.description())
-                    .clicked()
-                {
-                    settings_changed = true;
-                }
-            }
-        })
-        .response
-        .on_hover_text("Set dither mode and level for output\nThis can reduce some of the banding artifacts caused when the colors per palette is very small,\nat the expense of added \"noise\".");
+    settings_changed |= widgets::EnumCombo::new("dithering_mode", DitherMode::all(), DitherMode::display_name)
+        .description(DitherMode::description)
+        .hover("Set dither mode and level for output\nThis can reduce some of the banding artifacts caused when the colors per palette is very small,\nat the expense of added \"noise\".")
+        .show(ui, &mut state.settings.dither_mode);
 
     ui.horizontal(|ui| {
         ui.label("Dither Level:")
             .on_hover_text("Dithering intensity level");
-        if ui
+        settings_changed |= ui
             .add(egui::Slider::new(
                 &mut state.settings.dither_level,
                 0.0..=2.0,
             ))
             .on_hover_text("Adjust dithering intensity (0.0 = no dithering)")
-            .changed()
-        {
-            settings_changed = true;
-        }
+            .changed();
     });
 
     settings_changed
@@ -384,15 +343,14 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
     ui.heading_with_margin("Tile Reduction");
 
-    if ui
-        .checkbox(&mut state.settings.tile_reduce_post_enabled, "Enable (heavy)")
-        .on_hover_text(
+    settings_changed |= widgets::checkbox(
+        ui,
+        &mut state.settings.tile_reduce_post_enabled,
+        "Enable (heavy)",
+        Some(
             "Merge similar tiles after quantization using palette-aligned MSE.\nKeep threshold low to avoid visible changes.\nThis option increases processing time.",
-        )
-        .changed()
-    {
-        settings_changed = true;
-    }
+        ),
+    );
 
     // The settings only exist once the pass is turned on.
     if !state.settings.tile_reduce_post_enabled {
@@ -400,24 +358,18 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     }
 
     ui.horizontal(|ui| {
-        if ui
-            .checkbox(
-                &mut state.settings.tile_reduce_allow_flip_x,
-                "Allowed X Flips",
-            )
-            .changed()
-        {
-            settings_changed = true;
-        }
-        if ui
-            .checkbox(
-                &mut state.settings.tile_reduce_allow_flip_y,
-                "Allowed Y Flips",
-            )
-            .changed()
-        {
-            settings_changed = true;
-        }
+        settings_changed |= widgets::checkbox(
+            ui,
+            &mut state.settings.tile_reduce_allow_flip_x,
+            "Allowed X Flips",
+            None,
+        );
+        settings_changed |= widgets::checkbox(
+            ui,
+            &mut state.settings.tile_reduce_allow_flip_y,
+            "Allowed Y Flips",
+            None,
+        );
     });
 
     ui.horizontal(|ui| {
@@ -427,20 +379,15 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         let slider = egui::Slider::new(&mut state.settings.tile_reduce_post_threshold, 1.0..=500.0)
             .logarithmic(false)
             .show_value(false);
-        if ui.add(slider).changed() {
-            settings_changed = true;
-        }
+        settings_changed |= ui.add(slider).changed();
 
-        if ui
+        settings_changed |= ui
             .add(
                 egui::DragValue::new(&mut state.settings.tile_reduce_post_threshold)
                     .range(1.0..=500.0)
                     .speed(5.0),
             )
-            .changed()
-        {
-            settings_changed = true;
-        }
+            .changed();
     });
 
     let reduced_text = match (state.base_tile_count, state.reduced_tile_count) {
@@ -463,16 +410,14 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
 }
 
 fn draw_transparency_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
-    let mut settings_changed = false;
-
-    if ui
-        .checkbox(&mut state.settings.col0_is_clear, "First Color is Transparent")
-        .on_hover_text("First color of every palette is transparent\nNote that this affects both input AND output images.\nTo set transparency in a direct-color input bitmap, an alpha channel must be used (32-bit input);\ntranslucent alpha values are supported by this tool.")
-        .changed()
-    {
-        settings_changed = true;
-    }
-    settings_changed
+    widgets::checkbox(
+        ui,
+        &mut state.settings.col0_is_clear,
+        "First Color is Transparent",
+        Some(
+            "First color of every palette is transparent\nNote that this affects both input AND output images.\nTo set transparency in a direct-color input bitmap, an alpha channel must be used (32-bit input);\ntranslucent alpha values are supported by this tool.",
+        ),
+    )
 }
 
 fn draw_clustering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
@@ -482,24 +427,18 @@ fn draw_clustering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         ui.horizontal(|ui| {
             ui.label("Tile Passes:")
                 .on_hover_text("Set tile cluster passes (0 = default)");
-            if ui
+            settings_changed |= ui
                 .add(egui::DragValue::new(&mut state.settings.tile_passes).range(0..=1000))
                 .on_hover_text("Number of tile clustering passes (0 to 1000)")
-                .changed()
-            {
-                settings_changed = true;
-            }
+                .changed();
         });
         ui.horizontal(|ui| {
             ui.label("Color Passes:")
                 .on_hover_text("Set color cluster passes (0 = default)\nMost of the processing time will be spent in the loop that clusters the colors together.\nIf processing is taking excessive amounts of time, this option may be adjusted\n(e.g., for 256-color palettes, set to ~4; for 16-color palettes, set to 32-64)");
-            if ui
+            settings_changed |= ui
                 .add(egui::DragValue::new(&mut state.settings.color_passes).range(0..=100))
                 .on_hover_text("Number of color passes (0 to 100)")
-                .changed()
-            {
-                settings_changed = true;
-            }
+                .changed();
         });
     });
 
@@ -622,24 +561,21 @@ fn draw_gamma_row(ui: &mut egui::Ui, gamma: &mut f32, slider_width: f32) -> bool
     changed
 }
 
-fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
-    let mut settings_changed = false;
-
+/// Draws the color correction controls. These edit `state.color_correction`
+/// rather than `state.settings`, and app.rs detects that change on its own
+/// (comparing against the previous frame's value) to rebuild the corrected
+/// image, so none of this needs to report back a "settings changed" flag.
+fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) {
     ui.heading_with_margin("Color Correction");
 
-    if ui
-        .checkbox(&mut state.color_correction.enabled, "Enable")
+    ui.checkbox(&mut state.color_correction.enabled, "Enable")
         .on_hover_text(
             "Adjust the image before quantization.\nWhen off the input image is passed through untouched.",
-        )
-        .changed()
-    {
-        settings_changed = true;
-    }
+        );
 
     // The settings only exist once the pass is turned on.
     if !state.color_correction.enabled {
-        return settings_changed;
+        return;
     }
 
     egui::Grid::new("color_correction_grid")
@@ -654,44 +590,44 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bo
                 draw_slider_row(ui, label, value, range, format, slider_width)
             };
 
-            settings_changed |= row(
+            row(
                 "Brightness",
                 &mut correction.brightness,
                 BRIGHTNESS_RANGE,
                 ValueFormat::Percentage,
             );
-            settings_changed |= row(
+            row(
                 "Contrast",
                 &mut correction.contrast,
                 CONTRAST_RANGE,
                 ValueFormat::Decimal,
             );
-            settings_changed |= row(
+            row(
                 "Saturation",
                 &mut correction.saturation,
                 SATURATION_RANGE,
                 ValueFormat::Decimal,
             );
-            settings_changed |= row(
+            row(
                 "Hue Shift",
                 &mut correction.hue_shift,
                 HUE_SHIFT_RANGE,
                 ValueFormat::Degrees,
             );
-            settings_changed |= row(
+            row(
                 "Shadows",
                 &mut correction.shadows,
                 SHADOWS_RANGE,
                 ValueFormat::Percentage,
             );
-            settings_changed |= row(
+            row(
                 "Highlights",
                 &mut correction.highlights,
                 HIGHLIGHTS_RANGE,
                 ValueFormat::Percentage,
             );
 
-            settings_changed |= draw_gamma_row(ui, &mut correction.gamma, slider_width);
+            draw_gamma_row(ui, &mut correction.gamma, slider_width);
         });
 
     // Color correction presets
@@ -699,26 +635,23 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) -> bo
     ui.horizontal(|ui| {
         let button_width = (ui.available_width() - (4.0 * 8.0)) / 5.0;
 
-        let presets = [
-            ("🔄 Reset", ColorCorrection::default()),
-            ("Vibrant", ColorCorrection::preset_vibrant()),
-            ("Warm", ColorCorrection::preset_retro_warm()),
-            ("Cool", ColorCorrection::preset_retro_cool()),
-            ("Dark", ColorCorrection::preset_dark()),
-        ];
-
-        for (label, preset) in presets {
+        for preset in ColorCorrectionPreset::all() {
+            // The reset entry keeps its distinct icon label; the rest use the
+            // preset's own display name.
+            let label = match preset {
+                ColorCorrectionPreset::None => "🔄 Reset",
+                _ => preset.display_name(),
+            };
             if ui
                 .add_sized([button_width, ROW_HEIGHT], egui::Button::new(label))
                 .clicked()
             {
-                state.color_correction.apply_preset(preset);
-                settings_changed = true;
+                state
+                    .color_correction
+                    .apply_preset(preset.color_correction());
             }
         }
     });
-
-    settings_changed
 }
 
 fn draw_status_section(ui: &mut egui::Ui, state: &AppState) {

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -51,11 +51,6 @@ pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bo
     ui.separator();
     draw_palette_sort_settings(ui, state);
 
-    if state.preferences.show_debug_info {
-        // Debug information display
-        ui.separator();
-        draw_status_section(ui, state);
-    }
     (settings_changed, tile_reduce_changed)
 }
 
@@ -669,32 +664,6 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) {
             }
         }
     });
-}
-
-fn draw_status_section(ui: &mut egui::Ui, state: &AppState) {
-    ui.heading_with_margin("Debug Info");
-    if let Some(request_qualetize) = &state.request_update_qualetized_image {
-        let elapsed = request_qualetize.time.elapsed();
-        if elapsed < state.debounce_delay {
-            let remaining = state.debounce_delay - elapsed;
-            ui.label(format!(
-                "⏱ Preview will update in {:.1}s...",
-                remaining.as_secs_f32()
-            ));
-        }
-    }
-    // Debug information
-    ui.label(format!("Input path: {:?}", state.input_path.is_some()));
-    ui.label(format!("Input Image: {:?}", state.input_image.is_some()));
-    ui.label(format!(
-        "Color Corrected Image: {:?}",
-        state.color_corrected_image.is_some()
-    ));
-    ui.label(format!("Output Image: {:?}", state.output_image.is_some()));
-    ui.label(format!(
-        "Settings changed: {:?}",
-        state.request_update_qualetized_image.is_some(),
-    ));
 }
 
 /// Exactly 4 digits, each from 1-8.

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -98,11 +98,8 @@ fn draw_advanced_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
             }
             if ui.button("Use Top-Left Pixel Color").clicked()
                 && let Some(color_corrected_image) = &state.color_corrected_image
-                && let Some(color) = color_corrected_image.get_top_left_pixel_color()
             {
-                *r = color.r();
-                *g = color.g();
-                *b = color.b();
+                [*r, *g, *b, _] = color_corrected_image.top_left_pixel();
                 settings_changed = true;
             }
             ui.label(format!("#{:02X}{:02X}{:02X}", *r, *g, *b));

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -35,11 +35,9 @@ pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bo
 
     ui.separator();
 
-    // Advanced clustering settings (if enabled)
-    if state.preferences.show_advanced {
-        settings_changed |= draw_advanced_settings(ui, state);
-        ui.separator();
-    }
+    // Advanced settings, collapsed to their heading until shown
+    settings_changed |= draw_advanced_settings(ui, state);
+    ui.separator();
 
     // Color correction settings. These edit `state.color_correction`, not
     // `state.settings`, and app.rs already detects those changes itself, so
@@ -57,8 +55,20 @@ pub fn draw_settings_panel(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bo
 fn draw_advanced_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
 
-    ui.heading("Qualetize Advanced");
-    ui.add_space(4.0);
+    // Subheading, not heading: this is a subsection of "Qualetize" above,
+    // same as the "Color Space" and "Dithering" sections beside it.
+    widgets::subsection_header(
+        ui,
+        "Advanced Settings",
+        &mut state.preferences.show_advanced,
+        "Show",
+        Some(
+            "Tile size, output bit depth, transparent color, clustering passes and alpha handling.",
+        ),
+    );
+    if !state.preferences.show_advanced {
+        return settings_changed;
+    }
 
     settings_changed |= draw_tile_settings(ui, state);
 
@@ -336,14 +346,14 @@ fn draw_dithering_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
 
 fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     let mut settings_changed = false;
-    ui.heading_with_margin("Tile Reduction");
 
-    settings_changed |= widgets::checkbox(
+    settings_changed |= widgets::section_header(
         ui,
+        "Tile Reduction",
         &mut state.settings.tile_reduce_post_enabled,
-        "Enable (heavy)",
+        "Enable",
         Some(
-            "Merge similar tiles after quantization using palette-aligned MSE.\nKeep threshold low to avoid visible changes.\nThis option increases processing time.",
+            "Merge similar tiles after quantization using palette-aligned MSE.\nKeep threshold low to avoid visible changes.\nThis pass is heavy and increases processing time.",
         ),
     );
 
@@ -457,7 +467,9 @@ const GAMMA_STEP: f32 = 0.01;
 /// Round `value` to the nearest multiple of `step`, so a slider drag lands on
 /// the same values the number field can show and type.
 fn snap(value: f32, step: f32) -> f32 {
-    (value / step).round() * step
+    // `+ 0.0` normalizes a negative zero, which would otherwise be saved to
+    // the session file and shown as "-0%".
+    (value / step).round() * step + 0.0
 }
 
 /// How the numeric field next to a color correction slider is shown and parsed.
@@ -578,12 +590,15 @@ fn draw_gamma_row(ui: &mut egui::Ui, gamma: &mut f32, slider_width: f32) -> bool
 /// (comparing against the previous frame's value) to rebuild the corrected
 /// image, so none of this needs to report back a "settings changed" flag.
 fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.heading_with_margin("Color Correction");
-
-    ui.checkbox(&mut state.color_correction.enabled, "Enable")
-        .on_hover_text(
+    widgets::section_header(
+        ui,
+        "Color Correction",
+        &mut state.color_correction.enabled,
+        "Enable",
+        Some(
             "Adjust the image before quantization.\nWhen off the input image is passed through untouched.",
-        );
+        ),
+    );
 
     // The settings only exist once the pass is turned on.
     if !state.color_correction.enabled {
@@ -735,6 +750,7 @@ mod tests {
         assert_eq!(snap(-0.007, 0.01), -0.01);
         assert_eq!(snap(37.4, 1.0), 37.0);
         assert_eq!(snap(1.0, 0.01), 1.0);
+        assert!(snap(-0.001, 0.01).is_sign_positive(), "no negative zero");
     }
 
     #[test]

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -456,6 +456,14 @@ const SHADOWS_RANGE: RangeInclusive<f32> = -1.0..=1.0;
 const HIGHLIGHTS_RANGE: RangeInclusive<f32> = -1.0..=1.0;
 const GAMMA_RANGE: RangeInclusive<f32> = 0.1..=3.0;
 const GAMMA_DISPLAY_RANGE: RangeInclusive<f32> = -100.0..=100.0;
+/// Gamma is edited in hundredths, like the other decimal fields.
+const GAMMA_STEP: f32 = 0.01;
+
+/// Round `value` to the nearest multiple of `step`, so a slider drag lands on
+/// the same values the number field can show and type.
+fn snap(value: f32, step: f32) -> f32 {
+    (value / step).round() * step
+}
 
 /// How the numeric field next to a color correction slider is shown and parsed.
 #[derive(Clone, Copy)]
@@ -469,7 +477,9 @@ enum ValueFormat {
 }
 
 impl ValueFormat {
-    fn drag_speed(self) -> f64 {
+    /// Granularity of the value: one percent, one hundredth, or one degree.
+    /// Both the slider and the number field move in these steps.
+    fn step(self) -> f32 {
         match self {
             ValueFormat::Percentage | ValueFormat::Decimal => 0.01,
             ValueFormat::Degrees => 1.0,
@@ -513,18 +523,22 @@ fn draw_slider_row(
 ) -> bool {
     draw_row_label(ui, label);
 
+    let step = format.step();
     let mut changed = ui
         .add_sized(
             [slider_width, ROW_HEIGHT],
-            egui::Slider::new(value, range.clone()).show_value(false),
+            egui::Slider::new(value, range.clone())
+                .step_by(step as f64)
+                .show_value(false),
         )
         .changed();
 
-    let drag = egui::DragValue::new(value)
-        .range(range)
-        .speed(format.drag_speed());
+    let drag = egui::DragValue::new(value).range(range).speed(step as f64);
     changed |= ui.add(format.apply(drag)).changed();
 
+    if changed {
+        *value = snap(*value, step);
+    }
     ui.end_row();
     changed
 }
@@ -551,12 +565,15 @@ fn draw_gamma_row(ui: &mut egui::Ui, gamma: &mut f32, slider_width: f32) -> bool
         .add(
             egui::DragValue::new(gamma)
                 .range(GAMMA_RANGE)
-                .speed(0.01)
+                .speed(GAMMA_STEP as f64)
                 .custom_formatter(|n, _| format_gamma(n as f32))
                 .custom_parser(|s| s.parse::<f64>().ok()),
         )
         .changed();
 
+    if changed {
+        *gamma = snap(*gamma, GAMMA_STEP).clamp(*GAMMA_RANGE.start(), *GAMMA_RANGE.end());
+    }
     ui.end_row();
     changed
 }
@@ -741,6 +758,15 @@ fn draw_palette_sort_settings(ui: &mut egui::Ui, state: &mut AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snap_rounds_to_the_nearest_step() {
+        assert_eq!(snap(0.123, 0.01), 0.12);
+        assert_eq!(snap(0.126, 0.01), 0.13);
+        assert_eq!(snap(-0.007, 0.01), -0.01);
+        assert_eq!(snap(37.4, 1.0), 37.0);
+        assert_eq!(snap(1.0, 0.01), 1.0);
+    }
 
     #[test]
     fn valid_rgba_depths_report_no_error() {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -3,6 +3,8 @@
 
 use std::ops::RangeInclusive;
 
+use super::styles::RichTextExt;
+
 /// A `DragValue` bound to `range`, with a hover tooltip on the control itself.
 /// Returns whether the drag changed the value.
 pub fn drag_u16(
@@ -98,4 +100,66 @@ impl<'a, T: Copy + PartialEq + 'static> EnumCombo<'a, T> {
 
         changed
     }
+}
+
+/// A section heading with a toggle (an "Enable" or "Show" checkbox) aligned
+/// to the right edge of the same row, so the switch that governs a section
+/// sits on its title instead of taking a row of its own below it.
+/// Returns whether the toggle changed.
+pub fn section_header(
+    ui: &mut egui::Ui,
+    title: &str,
+    toggle: &mut bool,
+    toggle_label: &str,
+    hover: Option<&str>,
+) -> bool {
+    header_with_toggle(ui, toggle, toggle_label, hover, |ui| {
+        ui.heading(title);
+    })
+}
+
+/// Same as [`section_header`], but at the subheading level used for a
+/// settings block that is itself a subsection of a larger one (e.g.
+/// "Advanced Settings" under "Qualetize"), matching sibling subsections
+/// drawn with [`crate::ui::styles::UiMarginExt::subheading_with_margin`].
+pub fn subsection_header(
+    ui: &mut egui::Ui,
+    title: &str,
+    toggle: &mut bool,
+    toggle_label: &str,
+    hover: Option<&str>,
+) -> bool {
+    header_with_toggle(ui, toggle, toggle_label, hover, |ui| {
+        ui.label(egui::RichText::new(title).subheading());
+    })
+}
+
+/// Shared layout for [`section_header`] and [`subsection_header`]: draws
+/// `draw_title` on the left and a right-aligned toggle checkbox on the same
+/// row, inside the same Frame margin the two heading levels already use
+/// elsewhere. Returns whether the toggle changed.
+fn header_with_toggle(
+    ui: &mut egui::Ui,
+    toggle: &mut bool,
+    toggle_label: &str,
+    hover: Option<&str>,
+    draw_title: impl FnOnce(&mut egui::Ui),
+) -> bool {
+    let mut changed = false;
+    egui::Frame::NONE
+        .inner_margin(egui::Margin {
+            left: 0,
+            right: 0,
+            top: 2,
+            bottom: 4,
+        })
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                draw_title(ui);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    changed = checkbox(ui, toggle, toggle_label, hover);
+                });
+            });
+        });
+    changed
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,0 +1,101 @@
+//! Small helpers that collapse the settings panel's repeated
+//! `if ui.add(..).changed() { flag = true; }` blocks into one-liners.
+
+use std::ops::RangeInclusive;
+
+/// A `DragValue` bound to `range`, with a hover tooltip on the control itself.
+/// Returns whether the drag changed the value.
+pub fn drag_u16(
+    ui: &mut egui::Ui,
+    value: &mut u16,
+    range: RangeInclusive<u16>,
+    hover: &str,
+) -> bool {
+    ui.add(egui::DragValue::new(value).range(range))
+        .on_hover_text(hover)
+        .changed()
+}
+
+/// A checkbox with an optional hover tooltip. Returns whether it was toggled.
+pub fn checkbox(ui: &mut egui::Ui, value: &mut bool, label: &str, hover: Option<&str>) -> bool {
+    let response = ui.checkbox(value, label);
+    let response = match hover {
+        Some(hover) => response.on_hover_text(hover),
+        None => response,
+    };
+    response.changed()
+}
+
+/// A `ComboBox` over every value of an enum, labelled by `name`.
+///
+/// Built up with the optional parts a call site wants (per-entry tooltips,
+/// a tooltip on the closed control, a fixed width), then shown with
+/// [`Self::show`], which returns whether the selection changed.
+pub struct EnumCombo<'a, T: 'static> {
+    id: &'a str,
+    all: &'a [T],
+    name: fn(&T) -> &'static str,
+    description: Option<fn(&T) -> &'static str>,
+    hover: Option<&'a str>,
+    width: Option<f32>,
+}
+
+impl<'a, T: Copy + PartialEq + 'static> EnumCombo<'a, T> {
+    pub fn new(id: &'a str, all: &'a [T], name: fn(&T) -> &'static str) -> Self {
+        Self {
+            id,
+            all,
+            name,
+            description: None,
+            hover: None,
+            width: None,
+        }
+    }
+
+    /// Tooltip shown on each entry of the open list.
+    pub fn description(mut self, description: fn(&T) -> &'static str) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    /// Tooltip shown on the closed control.
+    pub fn hover(mut self, hover: &'a str) -> Self {
+        self.hover = Some(hover);
+        self
+    }
+
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Draw the combo bound to `value`; true when a different entry was picked.
+    pub fn show(self, ui: &mut egui::Ui, value: &mut T) -> bool {
+        let mut changed = false;
+
+        let mut combo = egui::ComboBox::from_id_salt(self.id).selected_text((self.name)(value));
+        if let Some(width) = self.width {
+            combo = combo.width(width);
+        }
+
+        let response = combo
+            .show_ui(ui, |ui| {
+                for item in self.all {
+                    let mut item_response = ui.selectable_value(value, *item, (self.name)(item));
+                    if let Some(description) = self.description {
+                        item_response = item_response.on_hover_text(description(item));
+                    }
+                    // `changed()` rather than `clicked()`: re-picking the current
+                    // entry must not trigger a re-quantization.
+                    changed |= item_response.changed();
+                }
+            })
+            .response;
+
+        if let Some(hover) = self.hover {
+            response.on_hover_text(hover);
+        }
+
+        changed
+    }
+}


### PR DESCRIPTION
Release 0.5.1.

Ordered dither modes sent the wrong kernel size to Qualetize (2x2 ran 4x4, 64x64 ran 512x512). Fixed, with the ids pinned to the C header.
- Settings loaded from disk are clamped before they reach the C library; settings and preferences are written atomically.
- The two background workers share one Job type; a settings change no longer starts a tile reduction on the stale base image; tile counts are computed in one place.
- Re-picking the current combo entry or typing an invalid level list no longer re-quantizes.
- Zoom is anchored on the pixel under the cursor.
- Color correction sliders move in fixed steps (1%, 0.01, 1°).
- Enable/Show toggles sit on the section title rows, Advanced Settings lives under Qualetize, Debug Info is gone.
