### PR TITLE
State facts only in comments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -701,7 +701,7 @@ mod tests {
         );
     }
 
-    /// Regression: `with_extension` used to reduce `hero.idle.png` to `hero.png`,
+    /// `with_extension` would truncate `hero.idle.png` to `hero.png`,
     /// dropping both the suffix and part of the original file name.
     #[test]
     fn export_path_preserves_dots_in_file_name() {

--- a/src/color_processor.rs
+++ b/src/color_processor.rs
@@ -191,8 +191,8 @@ mod tests {
         ]
     }
 
-    /// The lookup table replaced three per-pixel operations; it has to produce
-    /// bit-identical results, not merely close ones.
+    /// The lookup table must produce results bit-identical to the per-pixel
+    /// gamma/brightness/contrast computation, not merely close ones.
     #[test]
     fn tone_curve_is_bit_exact_with_the_per_pixel_computation() {
         for corrections in presets() {
@@ -213,8 +213,8 @@ mod tests {
         }
     }
 
-    /// chunks_exact/pixels_mut must visit the buffers in the same order as the
-    /// coordinate arithmetic it replaced.
+    /// chunks_exact/pixels_mut must visit the buffers in the same row-major
+    /// order as the per-pixel coordinate arithmetic.
     #[test]
     fn corrected_pixels_land_at_the_right_coordinates() {
         let (width, height) = (3u32, 2u32);

--- a/src/settings_manager/mod.rs
+++ b/src/settings_manager/mod.rs
@@ -196,7 +196,7 @@ mod tests {
 
         let bundle: SettingsBundle = serde_json::from_str(json).expect("loads");
         assert_eq!(bundle.qualetize_settings.tile_width, 8);
-        // Predates the flag, and back then correction was always applied.
+        // `enabled` is absent from this JSON, so it falls back to its serde default of `true`.
         assert!(bundle.color_correction.enabled);
         assert_eq!(bundle.sort_settings, PaletteSortSettings::default());
     }

--- a/src/types/color_correction.rs
+++ b/src/types/color_correction.rs
@@ -5,9 +5,9 @@ pub struct ColorCorrection {
     /// When off the input image is passed through untouched, the settings are
     /// hidden and no "Color Corrected" view is shown.
     ///
-    /// Settings files written before this flag existed were saved when color
-    /// correction was unconditional, so they load as enabled. A fresh
-    /// [`ColorCorrection::default()`] on the other hand starts disabled.
+    /// A settings file missing this field carries no on/off intent, so it
+    /// loads as enabled. A fresh [`ColorCorrection::default()`] on the other
+    /// hand starts disabled.
     #[serde(default = "enabled_when_missing")]
     pub enabled: bool,
     pub brightness: f32, // -1.0 to 1.0

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -296,8 +296,8 @@ fn default_tile_reduce_allow_flip() -> bool {
 /// Parses a 4-character RGBA depth string into per-channel level counts.
 ///
 /// Counts *characters*, not bytes: a non-ASCII string can have `len() == 4` in bytes
-/// while holding fewer than 4 `char`s (or vice versa), and indexing a byte-based
-/// `Vec<char>` built from the wrong count used to panic.
+/// while holding fewer than 4 `char`s (or vice versa), and indexing a `Vec<char>`
+/// built from the wrong count would panic.
 fn parse_rgba_depth(rgba_depth: &str) -> [f32; 4] {
     let chars: Vec<char> = rgba_depth.chars().collect();
     if let [a, b, c, d] = chars[..] {
@@ -453,9 +453,9 @@ impl From<QualetizeSettings> for QualetizePlanOwned {
 mod tests {
     use super::*;
 
-    /// `rgba_depth.len() == 4` used to check bytes, not characters, so a 4-byte
-    /// string that isn't 4 characters (e.g. containing multi-byte UTF-8) would pass
-    /// the length check and then panic indexing a shorter `Vec<char>`.
+    /// Checking `rgba_depth.len() == 4` would check bytes, not characters, so a
+    /// 4-byte string that isn't 4 characters (e.g. containing multi-byte UTF-8)
+    /// would pass that check and then panic indexing a shorter `Vec<char>`.
     #[test]
     fn parse_rgba_depth_does_not_panic_on_non_ascii_input() {
         // "é" is 2 bytes but 1 char: "é331" is 5 bytes / 4 chars, "éé31" is 6 bytes
@@ -471,10 +471,10 @@ mod tests {
     }
 
     /// `char_to_depth`'s formula (`2^d - 1` for a digit `d` in `1..=8`) must agree
-    /// with the explicit table it replaced.
+    /// with the explicit per-digit values below.
     #[test]
-    fn char_to_depth_formula_matches_the_old_table() {
-        let old_table = [
+    fn char_to_depth_formula_matches_the_digit_table() {
+        let table = [
             ('1', 1.0),
             ('2', 3.0),
             ('3', 7.0),
@@ -484,7 +484,7 @@ mod tests {
             ('7', 127.0),
             ('8', 255.0),
         ];
-        for (c, expected) in old_table {
+        for (c, expected) in table {
             assert_eq!(char_to_depth(c), expected, "digit {c}");
         }
         // Out of range or non-digit characters still fall back to 8-bit.
@@ -594,8 +594,8 @@ mod tests {
         }
     }
 
-    /// The regression this pair of helpers exists for: switching quantization
-    /// preset used to silently reset the tile reduction post-pass with it.
+    /// Applying a quantization preset would otherwise silently reset the tile
+    /// reduction post-pass along with it.
     #[test]
     fn applying_a_preset_leaves_tile_reduction_alone() {
         let mut settings = QualetizeSettings::genesis();

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,5 +1,5 @@
-//! Small helpers that collapse the settings panel's repeated
-//! `if ui.add(..).changed() { flag = true; }` blocks into one-liners.
+//! Widget helpers for the settings panel: each wraps an `egui` control and
+//! returns whether its value changed.
 
 use std::ops::RangeInclusive;
 


### PR DESCRIPTION
Comments and doc comments describe current behavior only; history and self-reference are removed. No code changes.