### PR TITLE
Fix the Pages build: pinned binaryen

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,8 +54,14 @@ jobs:
             cargo install wasm-bindgen-cli --version "$version" --locked
           fi
 
+      # A pinned binaryen release: the distribution package is too old for
+      # the reference-types table wasm-bindgen emits.
       - name: Install binaryen (wasm-opt)
-        run: sudo apt-get update && sudo apt-get install -y binaryen || echo "binaryen unavailable, wasm-opt step will be skipped"
+        run: |
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar xz -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/binaryen-version_${BINARYEN_VERSION}/bin" >> "$GITHUB_PATH"
+        env:
+          BINARYEN_VERSION: "123"
 
       - name: Build web
         run: scripts/build-web.sh

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Qualetize GUI</title>
+  <link rel="icon" href="data:,">
   <style>
     html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; background: #1c1c1c; }
     canvas { display: block; width: 100%; height: 100%; outline: none; }


### PR DESCRIPTION
The apt binaryen on the runner mangles the externref table wasm-bindgen emits, so the page failed at init with "WebAssembly.Table.grow(): failed to grow table". The workflow now downloads binaryen 123. The page also stops requesting a favicon.