### PR TITLE
Pages on tags, dithering presets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,8 @@ name: Pages
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 env:

--- a/examples/genesis.qset
+++ b/examples/genesis.qset
@@ -7,7 +7,7 @@
     "rgba_depth": "3331",
     "premul_alpha": false,
     "color_space": "RgbLinear",
-    "dither_mode": "None",
+    "dither_mode": "Floyd",
     "dither_level": 0.5,
     "tile_passes": 1000,
     "color_passes": 100,

--- a/src/types/qualetize.rs
+++ b/src/types/qualetize.rs
@@ -268,7 +268,7 @@ impl QualetizeSettings {
             rgba_depth: rgba_depth.clone(),
             premul_alpha: false,
             color_space: ColorSpace::default(),
-            dither_mode: DitherMode::None,
+            dither_mode: DitherMode::Floyd,
             dither_level: 0.5,
             tile_passes: 1000,
             color_passes: 100,

--- a/src/types/tilepalquant.rs
+++ b/src/types/tilepalquant.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TpqDitherMode {
-    #[default]
     Off,
     /// Dither only when assigning final pixel colors.
+    #[default]
     Fast,
     /// Evaluate palettes with dithering during optimization as well.
     Slow,
@@ -35,10 +35,10 @@ impl TpqDitherMode {
 /// which of the error-diffused candidates a pixel takes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum DitherPattern {
-    #[default]
     Diagonal4,
     Horizontal4,
     Vertical4,
+    #[default]
     Diagonal2,
     Horizontal2,
     Vertical2,
@@ -140,10 +140,11 @@ pub const FRACTION_OF_PIXELS_RANGE: std::ops::RangeInclusive<f32> = 0.01..=10.0;
 pub const DITHER_WEIGHT_RANGE: std::ops::RangeInclusive<f32> = 0.01..=1.0;
 
 impl TpqSettings {
-    /// Switch dithering off, which is what a Qualetize preset asks of the
-    /// engine-specific settings.
+    /// Restore the preset dithering: fast, Diagonal 2, weight 0.5.
     pub fn reset_dithering(&mut self) {
-        self.dither_mode = TpqDitherMode::Off;
+        self.dither_mode = TpqDitherMode::default();
+        self.dither_pattern = DitherPattern::default();
+        self.dither_weight = default_dither_weight();
     }
 
     /// Clamp values loaded from disk into the ranges the UI enforces.
@@ -181,7 +182,9 @@ mod tests {
             ..TpqSettings::default()
         };
         settings.reset_dithering();
-        assert_eq!(settings.dither_mode, TpqDitherMode::Off);
+        assert_eq!(settings.dither_mode, TpqDitherMode::Fast);
+        assert_eq!(settings.dither_pattern, DitherPattern::Diagonal2);
+        assert_eq!(settings.dither_weight, 0.5);
     }
 
     #[test]


### PR DESCRIPTION
The web build now deploys on a version tag (v*.*.*), like the release workflow, or by manual dispatch.
- Presets dither by default: Floyd-Steinberg at 0.5 for Qualetize, fast Diagonal 2 at 0.5 for tilepalquant.
