### PR TITLE
Attach the web build to releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,13 +5,18 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release to attach the web build to (e.g. v0.6.0); empty for none"
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
   WASI_SDK_VERSION: "34.0"
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -71,6 +76,32 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: web/dist
+
+      # The same files as a zip with index.html at its root, the layout
+      # static hosts such as itch.io expect.
+      - name: Create web archive
+        id: web_archive
+        run: |
+          name="qualetize-gui-${WEB_VERSION}-web.zip"
+          (cd web/dist && zip -r "$GITHUB_WORKSPACE/$name" .)
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+        env:
+          WEB_VERSION: ${{ inputs.release_tag || github.ref_name }}
+
+      - name: Upload web archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.web_archive.outputs.name }}
+          path: ${{ steps.web_archive.outputs.name }}
+
+      - name: Attach web archive to the release
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
+          files: ${{ steps.web_archive.outputs.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ qualetize_gui
 
 ## Web version
 
-A WebAssembly build is published to [https://ulalume.github.io/qualetize_gui/](https://ulalume.github.io/qualetize_gui/) by the `Pages` GitHub Actions workflow on every push to `main`. To build it locally, run `scripts/build-web.sh` and serve the resulting `web/dist` directory with any static file server.
+A WebAssembly build is published to [https://ulalume.github.io/qualetize_gui/](https://ulalume.github.io/qualetize_gui/) by the `Pages` GitHub Actions workflow on every version tag. The same files are attached to the [GitHub release](https://github.com/ulalume/qualetize_gui/releases/latest) as `qualetize-gui-<version>-web.zip`, with `index.html` at the root, for hosting elsewhere. To build it locally, run `scripts/build-web.sh` and serve the resulting `web/dist` directory with any static file server.
 
 ## Usage
 


### PR DESCRIPTION
The Pages workflow zips web/dist as qualetize-gui-<version>-web.zip, keeps it as a workflow artifact, and attaches it to the release of the tag that triggered it. A manual run can name an existing release to attach to. README notes the tag trigger and the zip.