### PR TITLE
Fix the web panic on random seeds; Random button

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -183,9 +183,6 @@ impl QualetizeApp {
 
         self.state.request_update_qualetized_image = None;
         self.image_processor.cancel_tile_reduce();
-        if self.state.tpq_settings.randomize_seed {
-            self.state.tpq_settings.rand_seed = rand_seed_from_clock();
-        }
         self.state.quantize_progress = Some(0);
         self.image_processor.start_quantize(
             &color_corrected_image.rgba_data,
@@ -688,16 +685,6 @@ fn large_image_size(request: &AppStateRequest) -> Option<(u32, u32)> {
     }
     .ok()?;
     (u64::from(width) * u64::from(height) >= LARGE_IMAGE_PIXELS).then_some((width, height))
-}
-
-/// A seed for a run that asked for a random one. Wall clock nanoseconds are
-/// plenty: the seed is recorded in the settings, so any value reproduces.
-fn rand_seed_from_clock() -> u32 {
-    let nanos = crate::time::SystemTime::now()
-        .duration_since(crate::time::UNIX_EPOCH)
-        .map(|d| d.subsec_nanos() ^ (d.as_secs() as u32))
-        .unwrap_or(0);
-    nanos.max(1)
 }
 
 /// Smallest size at or above `size` whose sides are multiples of the tile size.

--- a/src/app.rs
+++ b/src/app.rs
@@ -693,8 +693,8 @@ fn large_image_size(request: &AppStateRequest) -> Option<(u32, u32)> {
 /// A seed for a run that asked for a random one. Wall clock nanoseconds are
 /// plenty: the seed is recorded in the settings, so any value reproduces.
 fn rand_seed_from_clock() -> u32 {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let nanos = crate::time::SystemTime::now()
+        .duration_since(crate::time::UNIX_EPOCH)
         .map(|d| d.subsec_nanos() ^ (d.as_secs() as u32))
         .unwrap_or(0);
     nanos.max(1)

--- a/src/engine/tilepalquant/parity.rs
+++ b/src/engine/tilepalquant/parity.rs
@@ -184,7 +184,6 @@ fn check_case(case: &Case) -> Result<(), String> {
         dither_pattern: dither_pattern(&params.dither_pat),
         dither_weight: params.dither_wt,
         rand_seed: params.rand_seed,
-        randomize_seed: false,
         show_progress: false,
     };
     let cancel = AtomicBool::new(false);

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,10 +1,11 @@
-//! `Instant` for every target the app builds for.
+//! `Instant` and `SystemTime` for every target the app builds for.
 //!
-//! `std::time::Instant::now` panics on `wasm32-unknown-unknown`; `web_time`
-//! reads `performance.now()` there and re-exports `std`'s type elsewhere.
+//! `std::time::{Instant, SystemTime}::now` panic on `wasm32-unknown-unknown`;
+//! `web_time` reads `performance.now()` and `Date.now()` there and re-exports
+//! `std`'s types elsewhere.
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use std::time::Instant;
+pub use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 #[cfg(target_arch = "wasm32")]
-pub use web_time::Instant;
+pub use web_time::{Instant, SystemTime, UNIX_EPOCH};

--- a/src/types/tilepalquant.rs
+++ b/src/types/tilepalquant.rs
@@ -102,9 +102,6 @@ pub struct TpqSettings {
     pub dither_weight: f32,
     #[serde(default)]
     pub rand_seed: u32,
-    /// Pick a fresh seed for every run and write it back to `rand_seed`.
-    #[serde(default)]
-    pub randomize_seed: bool,
     /// Report intermediate quantizations while running.
     #[serde(default = "default_true")]
     pub show_progress: bool,
@@ -130,7 +127,6 @@ impl Default for TpqSettings {
             dither_pattern: DitherPattern::default(),
             dither_weight: default_dither_weight(),
             rand_seed: 0,
-            randomize_seed: false,
             show_progress: true,
         }
     }
@@ -138,6 +134,16 @@ impl Default for TpqSettings {
 
 pub const FRACTION_OF_PIXELS_RANGE: std::ops::RangeInclusive<f32> = 0.01..=10.0;
 pub const DITHER_WEIGHT_RANGE: std::ops::RangeInclusive<f32> = 0.01..=1.0;
+
+/// A fresh non-zero seed from the wall clock; the seed is recorded in the
+/// settings, so any value reproduces.
+pub fn random_seed() -> u32 {
+    let nanos = crate::time::SystemTime::now()
+        .duration_since(crate::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() ^ (d.as_secs() as u32))
+        .unwrap_or(0);
+    nanos.max(1)
+}
 
 impl TpqSettings {
     /// Restore the preset dithering: fast, Diagonal 2, weight 0.5.
@@ -214,7 +220,7 @@ mod tests {
     fn an_old_settings_file_still_loads_with_the_moved_fields_present() {
         let settings: TpqSettings = serde_json::from_str(
             r#"{"color_zero": "Shared", "shared_color": [1, 2, 3],
-                 "transparent_color": [4, 5, 6], "rand_seed": 7}"#,
+                 "transparent_color": [4, 5, 6], "rand_seed": 7, "randomize_seed": true}"#,
         )
         .expect("loads");
         assert_eq!(settings.rand_seed, 7);

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -6,7 +6,7 @@ use crate::color_processor::{
 use crate::engine::QuantEngine;
 use crate::types::qualetize::validate_0_255_array;
 use crate::types::tilepalquant::{
-    DITHER_WEIGHT_RANGE, DitherPattern, FRACTION_OF_PIXELS_RANGE, TpqDitherMode,
+    DITHER_WEIGHT_RANGE, DitherPattern, FRACTION_OF_PIXELS_RANGE, TpqDitherMode, random_seed,
 };
 use crate::types::{
     AppState, ColorSpace, DitherMode, FirstColor, QualetizePreset,
@@ -766,14 +766,14 @@ fn draw_tpq_misc_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         settings_changed |= ui
             .add(egui::DragValue::new(&mut state.tpq_settings.rand_seed))
             .changed();
-        settings_changed |= widgets::checkbox(
-            ui,
-            &mut state.tpq_settings.randomize_seed,
-            "Randomize each run",
-            Some(
-                "Pick a new seed for every run and store it here so the result can be reproduced.",
-            ),
-        );
+        if ui
+            .button("Random")
+            .on_hover_text("Pick a new seed")
+            .clicked()
+        {
+            state.tpq_settings.rand_seed = random_seed();
+            settings_changed = true;
+        }
     });
 
     settings_changed |= widgets::checkbox(


### PR DESCRIPTION
Random seeds read the clock through src/time.rs (web_time on wasm), fixing the web panic. A Random button next to the seed replaces the Randomize each run checkbox.