### PR TITLE
Checkbox section headings, engine names

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,8 +21,17 @@ pub enum QuantEngine {
 impl QuantEngine {
     pub fn display_name(&self) -> &'static str {
         match self {
-            QuantEngine::Qualetize => "Qualetize",
-            QuantEngine::TilePalQuant => "tilepalquant",
+            QuantEngine::Qualetize => "qualetize",
+            QuantEngine::TilePalQuant => "tiledpalettequant",
+        }
+    }
+
+    /// The upstream repository this engine is ported or bound from, shown as
+    /// a tooltip on the engine radio.
+    pub fn source(&self) -> &'static str {
+        match self {
+            QuantEngine::Qualetize => "Aikku93/qualetize",
+            QuantEngine::TilePalQuant => "rilden/tiledpalettequant",
         }
     }
 

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -196,6 +196,11 @@ pub struct AppState {
     // Palette Sort Settings
     pub palette_sort_settings: PaletteSortSettings,
     last_palette_sort_settings: PaletteSortSettings,
+    /// The mode to restore when the "Reorder palette colors" checkbox is
+    /// re-enabled after being turned off. Not persisted: only
+    /// `palette_sort_settings.mode` (which becomes [`SortMode::None`] while
+    /// off) is saved to the session.
+    pub palette_sort_mode_memory: SortMode,
     /// Set when the source of the sorted palette changed and it has to be recomputed.
     /// `output_palette_sorted_indexed_image` cannot be used for this on its own, because
     /// `None` is also the legitimate result of `SortMode::None`.
@@ -276,6 +281,10 @@ impl Default for AppState {
 
             palette_sort_settings: session.sort_settings,
             last_palette_sort_settings: session.sort_settings,
+            palette_sort_mode_memory: match session.sort_settings.mode {
+                SortMode::None => SortMode::Ramps,
+                mode => mode,
+            },
             palette_sort_dirty: false,
 
             tile_count: TileCountState::default(),

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -81,9 +81,11 @@ impl SortMode {
             Self::Ramps => "Ramps",
         }
     }
+    /// Every mode a color sort can actually run, in menu order.
+    /// [`Self::None`] (no sort) is not a menu entry: the "Reorder palette
+    /// colors" checkbox stands for it instead.
     pub fn all() -> &'static [Self] {
         &[
-            Self::None,
             Self::Ramps,
             Self::Luminance,
             Self::Hue,

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -1,4 +1,4 @@
-use super::styles::{UiMarginExt, error_color, warning_color};
+use super::styles::{error_color, warning_color};
 use super::widgets;
 use crate::color_processor::{
     display_value_to_gamma, format_gamma, format_percentage, gamma_to_display_value,
@@ -70,10 +70,11 @@ fn draw_quantization_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
     );
 
     ui.horizontal(|ui| {
-        ui.label("Qualetization engine:");
+        ui.label("Engine:");
         for engine in QuantEngine::all() {
             settings_changed |= ui
                 .radio_value(&mut state.engine, *engine, engine.display_name())
+                .on_hover_text(engine.source())
                 .changed();
         }
     });
@@ -122,7 +123,7 @@ fn draw_advanced_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
                 &mut state.preferences.show_advanced,
                 "Advanced",
                 Some(
-                    "Tile size and output bit depth, plus clustering passes and alpha handling (Qualetize) or the iteration budget, seed and progress preview (tilepalquant).",
+                    "Tile size and output bit depth, plus clustering passes and alpha handling (Qualetize) or the iteration budget, seed and progress preview (tiledpalettequant).",
                 ),
             );
         });
@@ -793,7 +794,6 @@ fn draw_tile_reduce_settings(ui: &mut egui::Ui, state: &mut AppState) -> bool {
         ui,
         "Tile reduction",
         &mut state.settings.tile_reduce_post_enabled,
-        "Enable",
         Some(
             "Merge similar tiles after quantization using palette-aligned MSE.\nKeep threshold low to avoid visible changes.\nThis pass is heavy and increases processing time.",
         ),
@@ -1024,7 +1024,6 @@ fn draw_color_correction_settings(ui: &mut egui::Ui, state: &mut AppState) {
         ui,
         "Color correction",
         &mut state.color_correction.enabled,
-        "Enable",
         Some(
             "Adjust the image before quantization.\nWhen off the input image is passed through untouched.",
         ),
@@ -1138,22 +1137,51 @@ fn get_rgba_depth_error(rgba_str: &str) -> Option<String> {
     None
 }
 
+/// "Reorder palette colors": a checkbox heading, matching the other two
+/// sections, standing for whether the mode is [`SortMode::None`]. Turning it
+/// off stores the active mode in `state.palette_sort_mode_memory` and sets
+/// the mode to `None`; turning it back on restores that remembered mode.
 fn draw_palette_sort_settings(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.heading_with_margin("Reorder palette colors");
+    let mode = &mut state.palette_sort_settings.mode;
+    let mut enabled = *mode != SortMode::None;
+    if widgets::section_header(ui, "Reorder palette colors", &mut enabled, None) {
+        if enabled {
+            *mode = match state.palette_sort_mode_memory {
+                SortMode::None => SortMode::Ramps,
+                remembered => remembered,
+            };
+        } else {
+            state.palette_sort_mode_memory = *mode;
+            *mode = SortMode::None;
+        }
+    }
 
-    ui.horizontal(|ui| {
-        egui::ComboBox::from_id_salt("sort_mode")
-            .selected_text(state.palette_sort_settings.mode.display_name())
-            .show_ui(ui, |ui| {
-                for sort_mode in SortMode::all() {
-                    ui.selectable_value(
-                        &mut state.palette_sort_settings.mode,
-                        *sort_mode,
-                        sort_mode.display_name(),
-                    );
-                }
-            });
-        ui.add_enabled_ui(state.palette_sort_settings.mode != SortMode::None, |ui| {
+    ui.add_enabled_ui(enabled, |ui| {
+        ui.horizontal(|ui| {
+            let mut mode_changed = false;
+            // While off the combo shows the mode that turning it on restores.
+            let shown = if enabled {
+                state.palette_sort_settings.mode
+            } else {
+                state.palette_sort_mode_memory
+            };
+            egui::ComboBox::from_id_salt("sort_mode")
+                .selected_text(shown.display_name())
+                .show_ui(ui, |ui| {
+                    for sort_mode in SortMode::all() {
+                        mode_changed |= ui
+                            .selectable_value(
+                                &mut state.palette_sort_settings.mode,
+                                *sort_mode,
+                                sort_mode.display_name(),
+                            )
+                            .changed();
+                    }
+                });
+            if mode_changed {
+                state.palette_sort_mode_memory = state.palette_sort_settings.mode;
+            }
+
             egui::ComboBox::from_id_salt("sort_order")
                 .selected_text(state.palette_sort_settings.order.display_name())
                 .show_ui(ui, |ui| {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -100,20 +100,37 @@ impl<'a, T: Copy + PartialEq + 'static> EnumCombo<'a, T> {
     }
 }
 
-/// A section heading with a toggle (an "Enable" or "Show" checkbox) aligned
-/// to the right edge of the same row, so the switch that governs a section
-/// sits on its title instead of taking a row of its own below it.
+/// A section heading that is itself the toggle governing the section: a
+/// checkbox whose label is the title, drawn in heading style, so the switch
+/// sits on the title instead of taking a row of its own. Clicking the title
+/// text toggles it, since egui checkbox labels are clickable.
 /// Returns whether the toggle changed.
 pub fn section_header(
     ui: &mut egui::Ui,
     title: &str,
     toggle: &mut bool,
-    toggle_label: &str,
     hover: Option<&str>,
 ) -> bool {
-    header_with_toggle(ui, toggle, toggle_label, hover, |ui| {
-        ui.heading(title);
-    })
+    let mut changed = false;
+    header_row(
+        ui,
+        |ui| {
+            // The checkbox square scales with the heading text instead of
+            // using the body-text size `ui.checkbox` defaults to.
+            let heading_height = ui.text_style_height(&egui::TextStyle::Heading);
+            ui.scope(|ui| {
+                ui.spacing_mut().icon_width = heading_height;
+                ui.spacing_mut().icon_width_inner = heading_height * 0.6;
+                let mut response = ui.checkbox(toggle, egui::RichText::new(title).heading());
+                if let Some(hover) = hover {
+                    response = response.on_hover_text(hover);
+                }
+                changed = response.changed();
+            });
+        },
+        |_ui| false,
+    );
+    changed
 }
 
 /// Shared layout for [`section_header`] and the Qualetization heading: draws
@@ -142,18 +159,4 @@ pub fn header_row(
             });
         });
     changed
-}
-
-/// [`header_row`] with a toggle checkbox as the right-aligned control, used
-/// by [`section_header`]. Returns whether the toggle changed.
-fn header_with_toggle(
-    ui: &mut egui::Ui,
-    toggle: &mut bool,
-    toggle_label: &str,
-    hover: Option<&str>,
-    draw_title: impl FnOnce(&mut egui::Ui),
-) -> bool {
-    header_row(ui, draw_title, |ui| {
-        checkbox(ui, toggle, toggle_label, hover)
-    })
 }


### PR DESCRIPTION
Color correction, Tile reduction and Reorder palette colors are headed by a checkbox whose label is the title. The palette sort combo no longer lists None: the checkbox stands for it and restores the previous mode when turned back on. The engine row is labelled Engine with qualetize and tiledpalettequant, each showing its source repository on hover.