### PR TITLE
Undo and redo of the settings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -657,9 +657,12 @@ impl eframe::App for QualetizeApp {
 
         // Record an undo step once the settings have stopped changing for a
         // moment, so a slider drag becomes one step instead of one per frame.
-        self.state
-            .history
-            .observe(&self.state.settings_bundle(), crate::time::Instant::now());
+        let pointer_down = ctx.input(|i| i.pointer.any_down());
+        self.state.history.observe(
+            &self.state.settings_bundle(),
+            crate::time::Instant::now(),
+            pointer_down,
+        );
         if self.state.history.pending() {
             ctx.request_repaint_after(crate::types::history::SETTLE);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -571,7 +571,29 @@ impl QualetizeApp {
             AppStateRequest::LoadSettingsDialog => {
                 platform::pick_settings_file(self.dialog_context(ctx))
             }
+            AppStateRequest::Undo => {
+                let current = self.state.settings_bundle();
+                if let Some(bundle) = self.state.history.undo(&current) {
+                    self.restore_settings_bundle(bundle, ctx);
+                }
+            }
+            AppStateRequest::Redo => {
+                let current = self.state.settings_bundle();
+                if let Some(bundle) = self.state.history.redo(&current) {
+                    self.restore_settings_bundle(bundle, ctx);
+                }
+            }
         }
+    }
+
+    /// Apply a bundle restored from undo/redo history, also keeping
+    /// `palette_sort_mode_memory` in sync so the "Reorder palette colors"
+    /// checkbox restores the right mode if it is re-enabled afterward.
+    fn restore_settings_bundle(&mut self, bundle: SettingsBundle, ctx: &egui::Context) {
+        if bundle.sort_settings.mode != SortMode::None {
+            self.state.palette_sort_mode_memory = bundle.sort_settings.mode;
+        }
+        self.apply_settings_bundle(bundle, ctx);
     }
 
     fn update_palette_sort_settings(&mut self) {
@@ -632,7 +654,42 @@ impl eframe::App for QualetizeApp {
         self.handle_tile_reduce_changes(ctx);
 
         self.update_palette_sort_settings();
+
+        // Record an undo step once the settings have stopped changing for a
+        // moment, so a slider drag becomes one step instead of one per frame.
+        self.state
+            .history
+            .observe(&self.state.settings_bundle(), crate::time::Instant::now());
+        if self.state.history.pending() {
+            ctx.request_repaint_after(crate::types::history::SETTLE);
+        }
+
         self.update_tile_counts();
+
+        // Redo is checked first: its shortcut is a superset of undo's. A
+        // focused text field keeps the shortcuts for its own undo.
+        let text_focused = ctx.memory(|m| m.focused().is_some());
+        let redo = !text_focused
+            && ctx.input_mut(|i| {
+                i.consume_key(
+                    egui::Modifiers::COMMAND | egui::Modifiers::SHIFT,
+                    egui::Key::Z,
+                )
+            });
+        let undo = !text_focused
+            && !redo
+            && ctx.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::Z));
+        if redo {
+            _ = self
+                .state
+                .app_state_request_sender
+                .send(AppStateRequest::Redo);
+        } else if undo {
+            _ = self
+                .state
+                .app_state_request_sender
+                .send(AppStateRequest::Undo);
+        }
 
         self.handle_requests(ctx);
         self.draw_large_image_prompt(ctx);

--- a/src/settings_manager/mod.rs
+++ b/src/settings_manager/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 /// Key the settings in use are kept under so they survive a restart.
 const SESSION_KEY: &str = "session";
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SettingsBundle {
     pub qualetize_settings: QualetizeSettings,
     pub color_correction: ColorCorrection,

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -12,6 +12,7 @@ use crate::engine::QuantEngine;
 use crate::settings_manager::SettingsBundle;
 use crate::time::Instant;
 use crate::types::FirstColor;
+use crate::types::history::SettingsHistory;
 use crate::types::image::TileCountOptions;
 use crate::types::tilepalquant::TpqSettings;
 
@@ -117,6 +118,9 @@ pub enum AppStateRequest {
     },
     SaveSettingsDialog,
     LoadSettingsDialog,
+
+    Undo,
+    Redo,
 }
 
 #[derive(Debug, Clone)]
@@ -213,6 +217,10 @@ pub struct AppState {
 
     pub tile_count: TileCountState,
 
+    /// Undo / redo history over the settings (engine, Qualetize settings,
+    /// tilepalquant settings, color correction, palette sort).
+    pub history: SettingsHistory,
+
     // Export requests
     pub app_state_request_receiver: mpsc::Receiver<AppStateRequest>,
     pub app_state_request_sender: mpsc::Sender<AppStateRequest>,
@@ -295,6 +303,19 @@ impl Default for AppState {
             palette_sort_dirty: false,
 
             tile_count: TileCountState::default(),
+
+            // Built the same way as `settings_bundle()`, so the initial
+            // history baseline matches what the first `observe` call sees
+            // (which stamps the current app version, not the session file's).
+            history: SettingsHistory::new(SettingsBundle {
+                engine: session.engine,
+                tpq_settings: session.tpq_settings.clone(),
+                ..SettingsBundle::new(
+                    session.qualetize_settings.clone(),
+                    session.color_correction.clone(),
+                    session.sort_settings,
+                )
+            }),
 
             app_state_request_receiver: receiver,
             app_state_request_sender: sender,

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -12,7 +12,7 @@ pub const CAP: usize = 100;
 /// How long a change has to sit unchanged before it is committed as its own
 /// undo step. This coalesces a slider drag (many changes in quick
 /// succession) into a single step instead of one per frame.
-pub const SETTLE: Duration = Duration::from_millis(300);
+pub const SETTLE: Duration = Duration::from_millis(600);
 
 /// Undo / redo history over the app's settings.
 ///

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -31,8 +31,9 @@ pub struct SettingsHistory {
     /// The most recently committed bundle: the baseline the next change is
     /// compared against.
     committed: SettingsBundle,
-    /// When the current (uncommitted) change first appeared.
-    pending_since: Option<Instant>,
+    /// The uncommitted settings last seen and when they last changed; the
+    /// settle timer restarts on every change.
+    pending: Option<(SettingsBundle, Instant)>,
 }
 
 impl SettingsHistory {
@@ -41,7 +42,7 @@ impl SettingsHistory {
             undo: Vec::new(),
             redo: Vec::new(),
             committed: initial,
-            pending_since: None,
+            pending: None,
         }
     }
 
@@ -54,34 +55,40 @@ impl SettingsHistory {
             self.undo.remove(0);
         }
         self.redo.clear();
-        self.pending_since = None;
+        self.pending = None;
     }
 
     /// Report the live settings for this frame. Returns `true` when a step
     /// was just recorded.
     ///
-    /// A change has to sit unchanged for [`SETTLE`] before it is committed,
-    /// so a slider drag becomes one undo step rather than one per frame.
-    pub fn observe(&mut self, current: &SettingsBundle, now: Instant) -> bool {
+    /// A change is committed once it has stayed the same for [`SETTLE`];
+    /// every further change restarts that timer, so a slider drag becomes
+    /// one undo step however long it lasts. `hold` postpones the commit
+    /// without restarting the timer, for as long as a pointer button is
+    /// down.
+    pub fn observe(&mut self, current: &SettingsBundle, now: Instant, hold: bool) -> bool {
         if *current == self.committed {
-            self.pending_since = None;
+            self.pending = None;
             return false;
         }
 
-        let since = *self.pending_since.get_or_insert(now);
-        if now.duration_since(since) >= SETTLE {
-            self.commit(current.clone());
-            true
-        } else {
-            false
+        match &self.pending {
+            Some((seen, since)) if seen == current => {
+                if !hold && now.duration_since(*since) >= SETTLE {
+                    self.commit(current.clone());
+                    return true;
+                }
+            }
+            _ => self.pending = Some((current.clone(), now)),
         }
+        false
     }
 
     /// A change is waiting to settle. The caller uses this to request a
     /// repaint after [`SETTLE`] so the step is recorded even without
     /// further input.
     pub fn pending(&self) -> bool {
-        self.pending_since.is_some()
+        self.pending.is_some()
     }
 
     /// Undo the last committed step, returning the bundle to restore.
@@ -95,7 +102,7 @@ impl SettingsHistory {
         let previous = self.undo.pop()?;
         self.redo
             .push(std::mem::replace(&mut self.committed, previous.clone()));
-        self.pending_since = None;
+        self.pending = None;
         Some(previous)
     }
 
@@ -110,7 +117,7 @@ impl SettingsHistory {
         let next = self.redo.pop()?;
         self.undo
             .push(std::mem::replace(&mut self.committed, next.clone()));
-        self.pending_since = None;
+        self.pending = None;
         Some(next)
     }
 
@@ -149,10 +156,10 @@ mod tests {
         let now = Instant::now();
         let changed = bundle(16);
 
-        assert!(!history.observe(&changed, now));
+        assert!(!history.observe(&changed, now, false));
         assert!(history.pending());
-        assert!(!history.observe(&changed, now + SETTLE - Duration::from_millis(1)));
-        assert!(history.observe(&changed, now + SETTLE));
+        assert!(!history.observe(&changed, now + SETTLE - Duration::from_millis(1), false));
+        assert!(history.observe(&changed, now + SETTLE, false));
         assert!(!history.pending());
         assert!(history.can_undo());
     }
@@ -163,13 +170,36 @@ mod tests {
         let mut history = SettingsHistory::new(start.clone());
         let now = Instant::now();
 
-        assert!(!history.observe(&bundle(16), now));
-        assert!(!history.observe(&bundle(24), now + Duration::from_millis(100)));
-        assert!(history.observe(&bundle(24), now + Duration::from_millis(100) + SETTLE));
+        assert!(!history.observe(&bundle(16), now, false));
+        assert!(!history.observe(&bundle(24), now + Duration::from_millis(100), false));
+        assert!(history.observe(
+            &bundle(24),
+            now + Duration::from_millis(100) + SETTLE,
+            false
+        ));
 
         // Only one step: undoing once returns to the original.
         let restored = history.undo(&bundle(24)).expect("a step was recorded");
         assert_eq!(restored, start);
+        assert!(!history.can_undo());
+    }
+
+    #[test]
+    fn a_change_that_keeps_moving_does_not_settle() {
+        let mut history = SettingsHistory::new(bundle(8));
+        let now = Instant::now();
+        let step = Duration::from_millis(100);
+
+        // Ten values in a row, each less than SETTLE after the previous one.
+        for i in 1..=10 {
+            assert!(!history.observe(&bundle(8 + i), now + step * i, false));
+        }
+        // Held down (dragging) it stays pending past SETTLE.
+        assert!(!history.observe(&bundle(18), now + step * 10 + SETTLE, true));
+        // Released and unchanged for SETTLE: exactly one step.
+        assert!(history.observe(&bundle(18), now + step * 10 + SETTLE, false));
+        let restored = history.undo(&bundle(18)).expect("a step was recorded");
+        assert_eq!(restored, bundle(8));
         assert!(!history.can_undo());
     }
 
@@ -179,8 +209,8 @@ mod tests {
         let mut history = SettingsHistory::new(start.clone());
         let changed = bundle(16);
         let now = Instant::now();
-        history.observe(&changed, now);
-        history.observe(&changed, now + SETTLE);
+        history.observe(&changed, now, false);
+        history.observe(&changed, now + SETTLE, false);
 
         let undone = history.undo(&changed).expect("a step to undo");
         assert_eq!(undone, start);
@@ -195,14 +225,14 @@ mod tests {
         let mut history = SettingsHistory::new(start.clone());
         let changed = bundle(16);
         let now = Instant::now();
-        history.observe(&changed, now);
-        history.observe(&changed, now + SETTLE);
+        history.observe(&changed, now, false);
+        history.observe(&changed, now + SETTLE, false);
         history.undo(&changed);
         assert!(history.can_redo());
 
         let other = bundle(24);
-        history.observe(&other, now + SETTLE + Duration::from_millis(1));
-        history.observe(&other, now + 2 * SETTLE + Duration::from_millis(1));
+        history.observe(&other, now + SETTLE + Duration::from_millis(1, false));
+        history.observe(&other, now + 2 * SETTLE + Duration::from_millis(1, false));
 
         assert!(!history.can_redo());
     }
@@ -215,7 +245,7 @@ mod tests {
         let now = Instant::now();
 
         // Change is observed but has not settled yet.
-        assert!(!history.observe(&changed, now));
+        assert!(!history.observe(&changed, now, false));
 
         let undone = history.undo(&changed).expect("the pending change to undo");
         assert_eq!(undone, start);
@@ -227,8 +257,8 @@ mod tests {
         let mut history = SettingsHistory::new(start.clone());
         let changed = bundle(16);
         let now = Instant::now();
-        history.observe(&changed, now);
-        history.observe(&changed, now + SETTLE);
+        history.observe(&changed, now, false);
+        history.observe(&changed, now + SETTLE, false);
         history.undo(&changed);
 
         // A new, unsettled change is committed first, which empties `redo`.
@@ -245,9 +275,9 @@ mod tests {
 
         for i in 1..=(CAP + 1) as u16 {
             let step = bundle(i);
-            history.observe(&step, now);
+            history.observe(&step, now, false);
             now += SETTLE;
-            history.observe(&step, now);
+            history.observe(&step, now, false);
         }
 
         assert_eq!(history.undo.len(), CAP);

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -1,0 +1,262 @@
+//! Undo / redo history over [`SettingsBundle`]: engine, Qualetize settings,
+//! tilepalquant settings, color correction and palette sort. Nothing else
+//! (image loading, zoom, panels) is undoable.
+
+use crate::settings_manager::SettingsBundle;
+use crate::time::Instant;
+use std::time::Duration;
+
+/// Maximum number of steps kept on the undo stack.
+pub const CAP: usize = 100;
+
+/// How long a change has to sit unchanged before it is committed as its own
+/// undo step. This coalesces a slider drag (many changes in quick
+/// succession) into a single step instead of one per frame.
+pub const SETTLE: Duration = Duration::from_millis(300);
+
+/// Undo / redo history over the app's settings.
+///
+/// Callers report the live settings every frame through [`observe`]; a
+/// change is only pushed onto the undo stack once it has stopped changing
+/// for [`SETTLE`]. [`undo`] and [`redo`] commit an unsettled change first,
+/// so undoing right after a change reverts that change rather than the one
+/// before it.
+///
+/// [`observe`]: SettingsHistory::observe
+/// [`undo`]: SettingsHistory::undo
+/// [`redo`]: SettingsHistory::redo
+pub struct SettingsHistory {
+    undo: Vec<SettingsBundle>,
+    redo: Vec<SettingsBundle>,
+    /// The most recently committed bundle: the baseline the next change is
+    /// compared against.
+    committed: SettingsBundle,
+    /// When the current (uncommitted) change first appeared.
+    pending_since: Option<Instant>,
+}
+
+impl SettingsHistory {
+    pub fn new(initial: SettingsBundle) -> Self {
+        Self {
+            undo: Vec::new(),
+            redo: Vec::new(),
+            committed: initial,
+            pending_since: None,
+        }
+    }
+
+    /// Push `committed` onto `undo`, dropping the oldest step above [`CAP`],
+    /// then adopt `new_committed` as the committed bundle and clear `redo`.
+    fn commit(&mut self, new_committed: SettingsBundle) {
+        self.undo
+            .push(std::mem::replace(&mut self.committed, new_committed));
+        if self.undo.len() > CAP {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+        self.pending_since = None;
+    }
+
+    /// Report the live settings for this frame. Returns `true` when a step
+    /// was just recorded.
+    ///
+    /// A change has to sit unchanged for [`SETTLE`] before it is committed,
+    /// so a slider drag becomes one undo step rather than one per frame.
+    pub fn observe(&mut self, current: &SettingsBundle, now: Instant) -> bool {
+        if *current == self.committed {
+            self.pending_since = None;
+            return false;
+        }
+
+        let since = *self.pending_since.get_or_insert(now);
+        if now.duration_since(since) >= SETTLE {
+            self.commit(current.clone());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// A change is waiting to settle. The caller uses this to request a
+    /// repaint after [`SETTLE`] so the step is recorded even without
+    /// further input.
+    pub fn pending(&self) -> bool {
+        self.pending_since.is_some()
+    }
+
+    /// Undo the last committed step, returning the bundle to restore.
+    ///
+    /// An unsettled change in `current` is committed first, so calling this
+    /// right after a change reverts that change.
+    pub fn undo(&mut self, current: &SettingsBundle) -> Option<SettingsBundle> {
+        if *current != self.committed {
+            self.commit(current.clone());
+        }
+        let previous = self.undo.pop()?;
+        self.redo
+            .push(std::mem::replace(&mut self.committed, previous.clone()));
+        self.pending_since = None;
+        Some(previous)
+    }
+
+    /// Redo the last undone step, returning the bundle to restore.
+    ///
+    /// An unsettled change in `current` is committed first; since committing
+    /// clears `redo`, redoing right after an unsettled change returns `None`.
+    pub fn redo(&mut self, current: &SettingsBundle) -> Option<SettingsBundle> {
+        if *current != self.committed {
+            self.commit(current.clone());
+        }
+        let next = self.redo.pop()?;
+        self.undo
+            .push(std::mem::replace(&mut self.committed, next.clone()));
+        self.pending_since = None;
+        Some(next)
+    }
+
+    pub fn can_undo(&self) -> bool {
+        !self.undo.is_empty()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        !self.redo.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        QualetizeSettings, color_correction::ColorCorrection, image::PaletteSortSettings,
+    };
+
+    fn bundle(tile_width: u16) -> SettingsBundle {
+        let settings = QualetizeSettings {
+            tile_width,
+            ..Default::default()
+        };
+        SettingsBundle::new(
+            settings,
+            ColorCorrection::default(),
+            PaletteSortSettings::default(),
+        )
+    }
+
+    #[test]
+    fn change_settles_after_delay_and_not_before() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let now = Instant::now();
+        let changed = bundle(16);
+
+        assert!(!history.observe(&changed, now));
+        assert!(history.pending());
+        assert!(!history.observe(&changed, now + SETTLE - Duration::from_millis(1)));
+        assert!(history.observe(&changed, now + SETTLE));
+        assert!(!history.pending());
+        assert!(history.can_undo());
+    }
+
+    #[test]
+    fn two_changes_within_settle_become_one_step() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let now = Instant::now();
+
+        assert!(!history.observe(&bundle(16), now));
+        assert!(!history.observe(&bundle(24), now + Duration::from_millis(100)));
+        assert!(history.observe(&bundle(24), now + Duration::from_millis(100) + SETTLE));
+
+        // Only one step: undoing once returns to the original.
+        let restored = history.undo(&bundle(24)).expect("a step was recorded");
+        assert_eq!(restored, start);
+        assert!(!history.can_undo());
+    }
+
+    #[test]
+    fn undo_then_redo_round_trips() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let changed = bundle(16);
+        let now = Instant::now();
+        history.observe(&changed, now);
+        history.observe(&changed, now + SETTLE);
+
+        let undone = history.undo(&changed).expect("a step to undo");
+        assert_eq!(undone, start);
+
+        let redone = history.redo(&start).expect("a step to redo");
+        assert_eq!(redone, changed);
+    }
+
+    #[test]
+    fn new_change_after_undo_clears_redo() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let changed = bundle(16);
+        let now = Instant::now();
+        history.observe(&changed, now);
+        history.observe(&changed, now + SETTLE);
+        history.undo(&changed);
+        assert!(history.can_redo());
+
+        let other = bundle(24);
+        history.observe(&other, now + SETTLE + Duration::from_millis(1));
+        history.observe(&other, now + 2 * SETTLE + Duration::from_millis(1));
+
+        assert!(!history.can_redo());
+    }
+
+    #[test]
+    fn undo_right_after_unsettled_change_reverts_it() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let changed = bundle(16);
+        let now = Instant::now();
+
+        // Change is observed but has not settled yet.
+        assert!(!history.observe(&changed, now));
+
+        let undone = history.undo(&changed).expect("the pending change to undo");
+        assert_eq!(undone, start);
+    }
+
+    #[test]
+    fn redo_right_after_unsettled_change_returns_none() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let changed = bundle(16);
+        let now = Instant::now();
+        history.observe(&changed, now);
+        history.observe(&changed, now + SETTLE);
+        history.undo(&changed);
+
+        // A new, unsettled change is committed first, which empties `redo`.
+        let other = bundle(24);
+        assert!(history.redo(&other).is_none());
+        assert!(!history.can_redo());
+    }
+
+    #[test]
+    fn cap_drops_the_oldest_step() {
+        let start = bundle(0);
+        let mut history = SettingsHistory::new(start.clone());
+        let mut now = Instant::now();
+
+        for i in 1..=(CAP + 1) as u16 {
+            let step = bundle(i);
+            history.observe(&step, now);
+            now += SETTLE;
+            history.observe(&step, now);
+        }
+
+        assert_eq!(history.undo.len(), CAP);
+        // The oldest step (the original `start`) was dropped, so undoing all
+        // the way back stops at `bundle(1)`, not `start`.
+        for _ in 0..CAP {
+            history.undo(&history.committed.clone());
+        }
+        assert!(!history.can_undo());
+        assert_eq!(history.committed, bundle(1));
+    }
+}

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -191,8 +191,8 @@ mod tests {
         let step = Duration::from_millis(100);
 
         // Ten values in a row, each less than SETTLE after the previous one.
-        for i in 1..=10 {
-            assert!(!history.observe(&bundle(8 + i), now + step * i, false));
+        for i in 1..=10u32 {
+            assert!(!history.observe(&bundle(8 + i as u16), now + step * i, false));
         }
         // Held down (dragging) it stays pending past SETTLE.
         assert!(!history.observe(&bundle(18), now + step * 10 + SETTLE, true));
@@ -231,8 +231,8 @@ mod tests {
         assert!(history.can_redo());
 
         let other = bundle(24);
-        history.observe(&other, now + SETTLE + Duration::from_millis(1, false));
-        history.observe(&other, now + 2 * SETTLE + Duration::from_millis(1, false));
+        history.observe(&other, now + SETTLE + Duration::from_millis(1), false);
+        history.observe(&other, now + 2 * SETTLE + Duration::from_millis(1), false);
 
         assert!(!history.can_redo());
     }

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -9,10 +9,18 @@ use std::time::Duration;
 /// Maximum number of steps kept on the undo stack.
 pub const CAP: usize = 100;
 
-/// How long a change has to sit unchanged before it is committed as its own
-/// undo step. This coalesces a slider drag (many changes in quick
-/// succession) into a single step instead of one per frame.
-pub const SETTLE: Duration = Duration::from_millis(600);
+/// How long a change made without the pointer (typing into a field) has to
+/// sit unchanged before it is committed as its own undo step, so a typed
+/// number becomes one step rather than one per keystroke. A change made
+/// while a pointer button is down commits the moment the button is
+/// released.
+pub const SETTLE: Duration = Duration::from_millis(300);
+
+struct Pending {
+    seen: SettingsBundle,
+    since: Instant,
+    held: bool,
+}
 
 /// Undo / redo history over the app's settings.
 ///
@@ -31,9 +39,9 @@ pub struct SettingsHistory {
     /// The most recently committed bundle: the baseline the next change is
     /// compared against.
     committed: SettingsBundle,
-    /// The uncommitted settings last seen and when they last changed; the
-    /// settle timer restarts on every change.
-    pending: Option<(SettingsBundle, Instant)>,
+    /// The uncommitted change: the settings last seen, when they last
+    /// changed, and whether a pointer button was down at any point of it.
+    pending: Option<Pending>,
 }
 
 impl SettingsHistory {
@@ -61,25 +69,40 @@ impl SettingsHistory {
     /// Report the live settings for this frame. Returns `true` when a step
     /// was just recorded.
     ///
-    /// A change is committed once it has stayed the same for [`SETTLE`];
-    /// every further change restarts that timer, so a slider drag becomes
-    /// one undo step however long it lasts. `hold` postpones the commit
-    /// without restarting the timer, for as long as a pointer button is
-    /// down.
+    /// `hold` is whether a pointer button is down. A change made while held
+    /// (a slider drag) is committed as one step the moment the button is
+    /// released, however long the drag took. A change made without the
+    /// pointer (typing) is committed once it has stayed the same for
+    /// [`SETTLE`].
     pub fn observe(&mut self, current: &SettingsBundle, now: Instant, hold: bool) -> bool {
         if *current == self.committed {
             self.pending = None;
             return false;
         }
 
-        match &self.pending {
-            Some((seen, since)) if seen == current => {
-                if !hold && now.duration_since(*since) >= SETTLE {
+        match &mut self.pending {
+            Some(pending) if pending.seen == *current => {
+                pending.held |= hold;
+                if hold {
+                    return false;
+                }
+                if pending.held || now.duration_since(pending.since) >= SETTLE {
                     self.commit(current.clone());
                     return true;
                 }
             }
-            _ => self.pending = Some((current.clone(), now)),
+            Some(pending) => {
+                pending.seen = current.clone();
+                pending.since = now;
+                pending.held |= hold;
+            }
+            None => {
+                self.pending = Some(Pending {
+                    seen: current.clone(),
+                    since: now,
+                    held: hold,
+                });
+            }
         }
         false
     }
@@ -196,11 +219,20 @@ mod tests {
         }
         // Held down (dragging) it stays pending past SETTLE.
         assert!(!history.observe(&bundle(18), now + step * 10 + SETTLE, true));
-        // Released and unchanged for SETTLE: exactly one step.
+        // Released: exactly one step, at once.
         assert!(history.observe(&bundle(18), now + step * 10 + SETTLE, false));
         let restored = history.undo(&bundle(18)).expect("a step was recorded");
         assert_eq!(restored, bundle(8));
         assert!(!history.can_undo());
+    }
+
+    #[test]
+    fn a_dragged_change_commits_on_release() {
+        let mut history = SettingsHistory::new(bundle(8));
+        let now = Instant::now();
+        assert!(!history.observe(&bundle(16), now, true));
+        assert!(history.observe(&bundle(16), now + Duration::from_millis(1), false));
+        assert!(history.can_undo());
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@ pub mod color_correction;
 pub mod color_space;
 pub mod dither;
 pub mod export;
+pub mod history;
 pub mod image;
 pub mod palette_ramps;
 pub mod preferences;

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -116,6 +116,35 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
 
         // --- Edit menu ---
         ui.menu_button("Edit", |ui| {
+            let undo_shortcut = egui::KeyboardShortcut::new(egui::Modifiers::COMMAND, egui::Key::Z);
+            let redo_shortcut = egui::KeyboardShortcut::new(
+                egui::Modifiers::COMMAND | egui::Modifiers::SHIFT,
+                egui::Key::Z,
+            );
+            if ui
+                .add_enabled(
+                    state.history.can_undo(),
+                    egui::Button::new("Undo")
+                        .shortcut_text(ui.ctx().format_shortcut(&undo_shortcut)),
+                )
+                .clicked()
+            {
+                _ = state.app_state_request_sender.send(AppStateRequest::Undo);
+                ui.close();
+            }
+            if ui
+                .add_enabled(
+                    state.history.can_redo(),
+                    egui::Button::new("Redo")
+                        .shortcut_text(ui.ctx().format_shortcut(&redo_shortcut)),
+                )
+                .clicked()
+            {
+                _ = state.app_state_request_sender.send(AppStateRequest::Redo);
+                ui.close();
+            }
+            ui.separator();
+
             ui.menu_button("Reset qualetization", |ui| {
                 for preset in QualetizePreset::all() {
                     if ui.button(preset.display_name()).clicked() {


### PR DESCRIPTION
Settings changes (engine, Qualetize, tiledpalettequant, color correction, palette sort) are recorded as undo steps once they have stopped changing for 300 ms, so a slider drag is one step. Edit menu gets Undo and Redo at the top, with Cmd/Ctrl+Z and Shift+Cmd/Ctrl+Z; the shortcuts are left to a focused text field.