### PR TITLE
Results panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "image",
  "js-sys",
  "log",
+ "miniz_oxide",
  "moxcms",
  "png",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ egui = "0.35"
 image = "0.25"
 moxcms = "0.8"
 log = "0.4"
+miniz_oxide = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 png = "0.18"

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,8 @@ use crate::types::app_state::{
 use crate::types::image::{ImageDataIndexed, SortMode};
 use crate::types::{AppState, ExportFormat};
 use crate::ui::{
-    draw_footer, draw_header, draw_image_view, draw_main_content, draw_settings_panel,
+    draw_footer, draw_header, draw_image_view, draw_main_content, draw_results_panel,
+    draw_settings_panel,
 };
 use eframe::egui;
 use egui::Margin;
@@ -585,7 +586,87 @@ impl QualetizeApp {
                     self.restore_settings_bundle(bundle, ctx);
                 }
             }
+            AppStateRequest::ApplyResult { hash } => {
+                let Some(settings) = self.result_settings(hash) else {
+                    return;
+                };
+                // Applying a result is a step of its own rather than a walk
+                // back through the history, so undo returns to the settings
+                // that were in use before it.
+                let before = self.state.settings_bundle();
+                self.restore_settings_bundle(settings.clone(), ctx);
+                self.state.history.record(&before, &settings);
+            }
+            AppStateRequest::ExportResult { hash } => self.export_result(hash, ctx),
+            AppStateRequest::RemoveResult { hash } => {
+                if let Some(index) = self.result_index(hash) {
+                    self.state.results.remove(index);
+                }
+                self.state.results_textures.remove(&hash);
+            }
         }
+    }
+
+    fn result_index(&self, hash: u64) -> Option<usize> {
+        self.state
+            .results
+            .entries()
+            .iter()
+            .position(|entry| entry.hash == hash)
+    }
+
+    fn result_settings(&self, hash: u64) -> Option<SettingsBundle> {
+        let index = self.result_index(hash)?;
+        Some(self.state.results.entries()[index].settings.clone())
+    }
+
+    /// Write a stored result out in the selected export format, decoding it
+    /// instead of re-running the pipeline. The name follows the export menu's:
+    /// the input file name plus the suffix of the pass the entry came from.
+    fn export_result(&mut self, hash: u64, ctx: &egui::Context) {
+        let Some(input_path) = self.state.input_path.clone() else {
+            return;
+        };
+        let Some(index) = self.result_index(hash) else {
+            log::error!("Export failed: no result {hash:016x} in the list");
+            return;
+        };
+        let entry = &self.state.results.entries()[index];
+        let format = self.state.preferences.selected_export_format;
+
+        let encoded = entry.decode().and_then(|indexed| {
+            let pixels = &indexed.indexed_pixels;
+            let palettes = &indexed.palettes;
+            match format {
+                ExportFormat::Bmp => {
+                    encode_indexed_bmp(pixels, palettes, entry.width, entry.height)
+                }
+                ExportFormat::PngIndexed => {
+                    encode_indexed_png(pixels, palettes, entry.width, entry.height)
+                }
+                ExportFormat::Png => Err("indexed export needs an indexed format".to_string()),
+            }
+        });
+        let bytes = match encoded {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                log::error!("Export failed: {e}");
+                return;
+            }
+        };
+
+        let source = if entry.settings.qualetize_settings.tile_reduce_post_enabled {
+            ExportSource::TileReduced
+        } else {
+            ExportSource::Qualetized
+        };
+        let default_path = platform::export_path(&input_path, format, Some(source.file_suffix()));
+        platform::export_image(
+            bytes,
+            default_path.display().to_string(),
+            format,
+            self.dialog_context(ctx),
+        );
     }
 
     /// Apply a bundle restored from undo/redo history, also keeping
@@ -817,6 +898,17 @@ impl eframe::App for QualetizeApp {
                     tile_reduce_changed |= tile_reduce;
                 });
             });
+
+        // Right (results)
+        if self.state.preferences.show_results {
+            egui::Panel::right("results_panel")
+                .default_size(200.0)
+                .min_size(120.0)
+                .resizable(true)
+                .show(ui, |ui| {
+                    draw_results_panel(ui, &mut self.state);
+                });
+        }
 
         // Center (images)
         egui::CentralPanel::default_margins()

--- a/src/app.rs
+++ b/src/app.rs
@@ -597,7 +597,6 @@ impl QualetizeApp {
                 self.restore_settings_bundle(settings.clone(), ctx);
                 self.state.history.record(&before, &settings);
             }
-            AppStateRequest::ExportResult { hash } => self.export_result(hash, ctx),
             AppStateRequest::RemoveResult { hash } => {
                 if let Some(index) = self.result_index(hash) {
                     self.state.results.remove(index);
@@ -618,55 +617,6 @@ impl QualetizeApp {
     fn result_settings(&self, hash: u64) -> Option<SettingsBundle> {
         let index = self.result_index(hash)?;
         Some(self.state.results.entries()[index].settings.clone())
-    }
-
-    /// Write a stored result out in the selected export format, decoding it
-    /// instead of re-running the pipeline. The name follows the export menu's:
-    /// the input file name plus the suffix of the pass the entry came from.
-    fn export_result(&mut self, hash: u64, ctx: &egui::Context) {
-        let Some(input_path) = self.state.input_path.clone() else {
-            return;
-        };
-        let Some(index) = self.result_index(hash) else {
-            log::error!("Export failed: no result {hash:016x} in the list");
-            return;
-        };
-        let entry = &self.state.results.entries()[index];
-        let format = self.state.preferences.selected_export_format;
-
-        let encoded = entry.decode().and_then(|indexed| {
-            let pixels = &indexed.indexed_pixels;
-            let palettes = &indexed.palettes;
-            match format {
-                ExportFormat::Bmp => {
-                    encode_indexed_bmp(pixels, palettes, entry.width, entry.height)
-                }
-                ExportFormat::PngIndexed => {
-                    encode_indexed_png(pixels, palettes, entry.width, entry.height)
-                }
-                ExportFormat::Png => Err("indexed export needs an indexed format".to_string()),
-            }
-        });
-        let bytes = match encoded {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                log::error!("Export failed: {e}");
-                return;
-            }
-        };
-
-        let source = if entry.settings.qualetize_settings.tile_reduce_post_enabled {
-            ExportSource::TileReduced
-        } else {
-            ExportSource::Qualetized
-        };
-        let default_path = platform::export_path(&input_path, format, Some(source.file_suffix()));
-        platform::export_image(
-            bytes,
-            default_path.display().to_string(),
-            format,
-            self.dialog_context(ctx),
-        );
     }
 
     /// Apply a bundle restored from undo/redo history, also keeping
@@ -902,7 +852,7 @@ impl eframe::App for QualetizeApp {
         // Right (results)
         if self.state.preferences.show_results {
             egui::Panel::right("results_panel")
-                .default_size(200.0)
+                .default_size(150.0)
                 .min_size(120.0)
                 .resizable(true)
                 .show(ui, |ui| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,6 +200,7 @@ impl QualetizeApp {
     fn install_input_image(&mut self, name: String, loaded: Result<ImageData, String>) {
         self.image_processor.cancel_all();
         self.state.reset_all_images();
+        self.state.record_result_when_idle = true;
 
         match loaded {
             Ok(image_data) => {
@@ -498,6 +499,7 @@ impl QualetizeApp {
     /// Replace the settings in use with `bundle`.
     fn apply_settings_bundle(&mut self, bundle: SettingsBundle, ctx: &egui::Context) {
         self.image_processor.cancel_all();
+        self.state.record_result_when_idle = true;
         self.state.engine = bundle.engine;
         self.state.settings = bundle.qualetize_settings;
         self.state.tpq_settings = bundle.tpq_settings;
@@ -596,6 +598,61 @@ impl QualetizeApp {
         self.apply_settings_bundle(bundle, ctx);
     }
 
+    /// Nothing is queued or running, so `output_image` is the finished result
+    /// for the settings in use.
+    fn pipeline_idle(&self) -> bool {
+        !self.image_processor.is_quantizing()
+            && !self.image_processor.is_tile_reducing()
+            && self.state.request_update_qualetized_image.is_none()
+            && !self.state.request_update_tile_reduce
+            && !self.state.palette_sort_needs_update()
+    }
+
+    /// Store the displayed output as a result, together with the settings
+    /// that produced it. The image is the one the Export button writes: the
+    /// tile reduced pass when it is enabled, otherwise the quantized one.
+    fn record_result(&mut self) {
+        let source = if self.state.settings.tile_reduce_post_enabled {
+            ExportSource::TileReduced
+        } else {
+            ExportSource::Qualetized
+        };
+        let Some((indexed, width, height)) = self.state.indexed_for_export(source) else {
+            return;
+        };
+        let settings = self.state.settings_bundle();
+        // The palette sort only reorders palette entries and remaps the
+        // indices to match, so the displayed RGBA is the sorted image's too.
+        let Some(rgba) = self
+            .state
+            .output_image
+            .as_ref()
+            .map(|image| &image.rgba_data)
+        else {
+            return;
+        };
+
+        let added = self.state.results.record(
+            &indexed,
+            rgba,
+            width,
+            height,
+            settings,
+            crate::time::Instant::now(),
+        );
+        let compressed = self
+            .state
+            .results
+            .entries()
+            .first()
+            .map_or(0, |entry| entry.compressed_len());
+        log::info!(
+            "{} result: {} entries, {compressed} bytes compressed",
+            if added { "Recorded" } else { "Refreshed" },
+            self.state.results.len(),
+        );
+    }
+
     fn update_palette_sort_settings(&mut self) {
         if !self.state.palette_sort_needs_update() {
             return;
@@ -658,13 +715,26 @@ impl eframe::App for QualetizeApp {
         // Record an undo step once the settings have stopped changing for a
         // moment, so a slider drag becomes one step instead of one per frame.
         let pointer_down = ctx.input(|i| i.pointer.any_down());
-        self.state.history.observe(
+        let committed = self.state.history.observe(
             &self.state.settings_bundle(),
             crate::time::Instant::now(),
             pointer_down,
         );
         if self.state.history.pending() {
             ctx.request_repaint_after(crate::types::history::SETTLE);
+        }
+        if committed {
+            self.state.record_result_when_idle = true;
+        }
+
+        // A result is recorded once the pipeline has finished the step the
+        // history committed. Settings that moved on again since that step
+        // drop the request; the next committed step raises it anew.
+        if self.state.record_result_when_idle && self.pipeline_idle() {
+            self.state.record_result_when_idle = false;
+            if self.state.settings_bundle() == *self.state.history.committed() {
+                self.record_result();
+            }
         }
 
         self.update_tile_counts();

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -128,10 +128,6 @@ pub enum AppStateRequest {
     ApplyResult {
         hash: u64,
     },
-    /// Write the result with this hash out in the selected export format.
-    ExportResult {
-        hash: u64,
-    },
     /// Drop the result with this hash from the list.
     RemoveResult {
         hash: u64,

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -14,6 +14,7 @@ use crate::time::Instant;
 use crate::types::FirstColor;
 use crate::types::history::SettingsHistory;
 use crate::types::image::TileCountOptions;
+use crate::types::results::Results;
 use crate::types::tilepalquant::TpqSettings;
 
 #[derive(
@@ -221,6 +222,12 @@ pub struct AppState {
     /// tilepalquant settings, color correction, palette sort).
     pub history: SettingsHistory,
 
+    /// Completed outputs with the settings that produced them, newest first.
+    pub results: Results,
+    /// A step was committed to the history and the result it belongs to is
+    /// still being produced; the next idle frame records it.
+    pub record_result_when_idle: bool,
+
     // Export requests
     pub app_state_request_receiver: mpsc::Receiver<AppStateRequest>,
     pub app_state_request_sender: mpsc::Sender<AppStateRequest>,
@@ -316,6 +323,9 @@ impl Default for AppState {
                     session.sort_settings,
                 )
             }),
+
+            results: Results::default(),
+            record_result_when_idle: false,
 
             app_state_request_receiver: receiver,
             app_state_request_sender: sender,
@@ -563,6 +573,7 @@ impl AppState {
         self.tile_fitted_input = None;
         self.tile_fit_toast = None;
         self.color_corrected_image = None;
+        self.results.clear();
         self.reset_qualetize_outputs();
     }
 }

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -15,7 +15,7 @@ use crate::time::Instant;
 use crate::types::FirstColor;
 use crate::types::history::SettingsHistory;
 use crate::types::image::TileCountOptions;
-use crate::types::results::Results;
+use crate::types::results::{Results, ResultsView};
 use crate::types::tilepalquant::TpqSettings;
 
 #[derive(
@@ -247,6 +247,9 @@ pub struct AppState {
     ///
     /// [`StoredResult::hash`]: crate::types::results::StoredResult::hash
     pub results_textures: HashMap<u64, ResultTextures>,
+    /// The order the list was drawn in and the animation a change to it
+    /// started.
+    pub results_view: ResultsView,
     /// A step was committed to the history and the result it belongs to is
     /// still being produced; the next idle frame records it.
     pub record_result_when_idle: bool,
@@ -349,6 +352,7 @@ impl Default for AppState {
 
             results: Results::default(),
             results_textures: HashMap::new(),
+            results_view: ResultsView::default(),
             record_result_when_idle: false,
 
             app_state_request_receiver: receiver,

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -1,4 +1,5 @@
 use egui::Vec2;
+use std::collections::HashMap;
 use std::sync::{Arc, atomic::AtomicBool, mpsc};
 
 use super::{
@@ -122,6 +123,28 @@ pub enum AppStateRequest {
 
     Undo,
     Redo,
+
+    /// Put the settings of the result with this hash back in use.
+    ApplyResult {
+        hash: u64,
+    },
+    /// Write the result with this hash out in the selected export format.
+    ExportResult {
+        hash: u64,
+    },
+    /// Drop the result with this hash from the list.
+    RemoveResult {
+        hash: u64,
+    },
+}
+
+/// The textures a result entry is drawn from, uploaded as rows become
+/// visible. `full` only exists while the panel is wide enough to show the
+/// image above thumbnail size.
+#[derive(Default)]
+pub struct ResultTextures {
+    pub thumbnail: Option<egui::TextureHandle>,
+    pub full: Option<egui::TextureHandle>,
 }
 
 #[derive(Debug, Clone)]
@@ -224,6 +247,10 @@ pub struct AppState {
 
     /// Completed outputs with the settings that produced them, newest first.
     pub results: Results,
+    /// Textures of the drawn result entries, keyed by [`StoredResult::hash`].
+    ///
+    /// [`StoredResult::hash`]: crate::types::results::StoredResult::hash
+    pub results_textures: HashMap<u64, ResultTextures>,
     /// A step was committed to the history and the result it belongs to is
     /// still being produced; the next idle frame records it.
     pub record_result_when_idle: bool,
@@ -325,6 +352,7 @@ impl Default for AppState {
             }),
 
             results: Results::default(),
+            results_textures: HashMap::new(),
             record_result_when_idle: false,
 
             app_state_request_receiver: receiver,
@@ -574,6 +602,7 @@ impl AppState {
         self.tile_fit_toast = None;
         self.color_corrected_image = None;
         self.results.clear();
+        self.results_textures.clear();
         self.reset_qualetize_outputs();
     }
 }

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -107,6 +107,21 @@ impl SettingsHistory {
         false
     }
 
+    /// Record `next` as its own step, without waiting for it to settle.
+    ///
+    /// An unsettled change in `current` is committed first, so applying a
+    /// stored result right after moving a slider keeps both as separate
+    /// steps. Settings that are already the committed ones add nothing.
+    pub fn record(&mut self, current: &SettingsBundle, next: &SettingsBundle) {
+        if *current != self.committed {
+            self.commit(current.clone());
+        }
+        if *next != self.committed {
+            self.commit(next.clone());
+        }
+        self.pending = None;
+    }
+
     /// A change is waiting to settle. The caller uses this to request a
     /// repaint after [`SETTLE`] so the step is recorded even without
     /// further input.
@@ -303,6 +318,32 @@ mod tests {
         let other = bundle(24);
         assert!(history.redo(&other).is_none());
         assert!(!history.can_redo());
+    }
+
+    #[test]
+    fn record_commits_the_unsettled_change_and_the_new_one_as_two_steps() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        let unsettled = bundle(16);
+        history.observe(&unsettled, Instant::now(), false);
+        assert!(history.pending());
+
+        let applied = bundle(24);
+        history.record(&unsettled, &applied);
+        assert!(!history.pending());
+        assert_eq!(*history.committed(), applied);
+
+        assert_eq!(history.undo(&applied).expect("the applied step"), unsettled);
+        assert_eq!(history.undo(&unsettled).expect("the earlier step"), start);
+        assert!(!history.can_undo());
+    }
+
+    #[test]
+    fn recording_the_settings_already_in_place_adds_no_step() {
+        let start = bundle(8);
+        let mut history = SettingsHistory::new(start.clone());
+        history.record(&start, &start);
+        assert!(!history.can_undo());
     }
 
     #[test]

--- a/src/types/history.rs
+++ b/src/types/history.rs
@@ -144,6 +144,12 @@ impl SettingsHistory {
         Some(next)
     }
 
+    /// The bundle the last committed step left in place: what an uncommitted
+    /// change is compared against.
+    pub fn committed(&self) -> &SettingsBundle {
+        &self.committed
+    }
+
     pub fn can_undo(&self) -> bool {
         !self.undo.is_empty()
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,6 +8,7 @@ pub mod image;
 pub mod palette_ramps;
 pub mod preferences;
 pub mod qualetize;
+pub mod results;
 pub mod tilepalquant;
 
 // Re-export all public types for convenience
@@ -18,3 +19,4 @@ pub use dither::DitherMode;
 pub use export::ExportFormat;
 pub use image::ImageData;
 pub use qualetize::{BGRA8, ClearColor, FirstColor, QualetizePreset, QualetizeSettings};
+pub use results::{Results, StoredResult};

--- a/src/types/preferences.rs
+++ b/src/types/preferences.rs
@@ -33,12 +33,18 @@ mod color32_def {
     }
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserPreferences {
     #[serde(default)]
     pub show_advanced: bool,
     #[serde(default)]
     pub show_palettes: bool,
+    #[serde(default = "default_true")]
+    pub show_results: bool,
 
     #[serde(default)]
     pub show_appearance: bool,
@@ -57,6 +63,7 @@ impl Default for UserPreferences {
         Self {
             show_advanced: false,
             show_palettes: true,
+            show_results: true,
             show_appearance: false,
             selected_export_format: ExportFormat::default(),
             appearance_mode: AppearanceMode::default(),
@@ -97,6 +104,7 @@ mod tests {
         let prefs: UserPreferences = serde_json::from_str("{}").expect("loads");
         assert_eq!(prefs.selected_export_format, ExportFormat::PngIndexed);
         assert_eq!(prefs.background_color, None);
+        assert!(prefs.show_results);
     }
 
     /// A preferences file written before a field existed is missing just that one

--- a/src/types/results.rs
+++ b/src/types/results.rs
@@ -1,0 +1,401 @@
+//! Completed outputs kept alongside the settings that produced them.
+//!
+//! An entry holds the full resolution indexed image (deflate compressed) so
+//! it can be exported without re-running the pipeline, a thumbnail for the
+//! list, and the [`SettingsBundle`] the image came from.
+
+use crate::settings_manager::SettingsBundle;
+use crate::time::Instant;
+use crate::types::BGRA8;
+use crate::types::image::ImageDataIndexed;
+
+/// Maximum number of entries kept; the oldest are dropped past this.
+pub const CAP: usize = 50;
+
+/// Longest side of a thumbnail, in pixels.
+pub const THUMBNAIL_SIZE: u32 = 160;
+
+/// Deflate level used for the indexed pixels: a compromise between the
+/// time spent on the UI thread and the memory an entry occupies.
+const COMPRESSION_LEVEL: u8 = 6;
+
+/// A downscaled RGBA copy of a result, for the list.
+pub struct Thumbnail {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
+/// One completed output.
+pub struct StoredResult {
+    /// Of the indexed pixels and the palettes, for duplicate detection.
+    pub hash: u64,
+    /// The settings the image was produced with.
+    pub settings: SettingsBundle,
+    pub width: u32,
+    pub height: u32,
+    pub colors_per_palette: usize,
+    pub palettes: Vec<BGRA8>,
+    /// Indexed pixels, deflate compressed; [`StoredResult::decode`] restores them.
+    pixels: Vec<u8>,
+    pub thumbnail: Thumbnail,
+    pub created: Instant,
+}
+
+impl StoredResult {
+    /// Rebuild the full resolution indexed image.
+    pub fn decode(&self) -> Result<ImageDataIndexed, String> {
+        let pixels = miniz_oxide::inflate::decompress_to_vec(&self.pixels)
+            .map_err(|e| format!("Failed to decompress result pixels: {e:?}"))?;
+        let expected = self.width as usize * self.height as usize;
+        if pixels.len() != expected {
+            return Err(format!(
+                "Result pixels are {} bytes, expected {expected}",
+                pixels.len()
+            ));
+        }
+        Ok(ImageDataIndexed::new(
+            self.palettes.clone(),
+            self.colors_per_palette,
+            pixels,
+        ))
+    }
+
+    /// Size of the compressed pixels in bytes.
+    pub fn compressed_len(&self) -> usize {
+        self.pixels.len()
+    }
+}
+
+/// The recorded results, newest first.
+pub struct Results {
+    entries: Vec<StoredResult>,
+    cap: usize,
+}
+
+impl Default for Results {
+    fn default() -> Self {
+        Self::new(CAP)
+    }
+}
+
+impl Results {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            entries: Vec::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Record `indexed` as the newest entry.
+    ///
+    /// An image already in the list (same hash) is moved to the front with
+    /// its settings and timestamp refreshed rather than stored twice;
+    /// `true` means a new entry was added.
+    pub fn record(
+        &mut self,
+        indexed: &ImageDataIndexed,
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+        settings: SettingsBundle,
+        now: Instant,
+    ) -> bool {
+        let hash = hash_result(&indexed.indexed_pixels, &indexed.palettes);
+
+        if let Some(index) = self.entries.iter().position(|entry| entry.hash == hash) {
+            let mut entry = self.entries.remove(index);
+            entry.settings = settings;
+            entry.created = now;
+            self.entries.insert(0, entry);
+            return false;
+        }
+
+        let entry = StoredResult {
+            hash,
+            settings,
+            width,
+            height,
+            colors_per_palette: indexed.colors_per_palette(),
+            palettes: indexed.palettes.clone(),
+            pixels: miniz_oxide::deflate::compress_to_vec(
+                &indexed.indexed_pixels,
+                COMPRESSION_LEVEL,
+            ),
+            thumbnail: thumbnail_of(rgba, width, height),
+            created: now,
+        };
+        self.entries.insert(0, entry);
+        self.entries.truncate(self.cap);
+        true
+    }
+
+    pub fn entries(&self) -> &[StoredResult] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop the entry at `index`, ignoring an index past the end.
+    pub fn remove(&mut self, index: usize) {
+        if index < self.entries.len() {
+            self.entries.remove(index);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+/// FNV-1a over the pixels followed by the palette bytes.
+fn hash_result(pixels: &[u8], palettes: &[BGRA8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = OFFSET;
+    let mut eat = |byte: u8| {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(PRIME);
+    };
+    for &pixel in pixels {
+        eat(pixel);
+    }
+    for color in palettes {
+        eat(color.b);
+        eat(color.g);
+        eat(color.r);
+        eat(color.a);
+    }
+    hash
+}
+
+/// Downscale `rgba` so its longest side is [`THUMBNAIL_SIZE`], averaging the
+/// source pixels that fall into each destination cell. An image already that
+/// small is kept as it is.
+pub fn thumbnail_of(rgba: &[u8], width: u32, height: u32) -> Thumbnail {
+    let longest = width.max(height);
+    if width == 0 || height == 0 || longest <= THUMBNAIL_SIZE {
+        return Thumbnail {
+            width,
+            height,
+            rgba: rgba.to_vec(),
+        };
+    }
+
+    let scale = THUMBNAIL_SIZE as f64 / longest as f64;
+    let dst_width = ((width as f64 * scale).round() as u32).max(1);
+    let dst_height = ((height as f64 * scale).round() as u32).max(1);
+
+    let cells = dst_width as usize * dst_height as usize;
+    let mut sums = vec![[0u64; 4]; cells];
+    let mut counts = vec![0u64; cells];
+
+    for y in 0..height as usize {
+        let dst_y = (((y as f64 + 0.5) * scale) as usize).min(dst_height as usize - 1);
+        let row = dst_y * dst_width as usize;
+        for x in 0..width as usize {
+            let dst_x = (((x as f64 + 0.5) * scale) as usize).min(dst_width as usize - 1);
+            let src = (y * width as usize + x) * 4;
+            let Some(pixel) = rgba.get(src..src + 4) else {
+                continue;
+            };
+            let cell = row + dst_x;
+            for (sum, &channel) in sums[cell].iter_mut().zip(pixel) {
+                *sum += channel as u64;
+            }
+            counts[cell] += 1;
+        }
+    }
+
+    let mut out = Vec::with_capacity(cells * 4);
+    for (sum, count) in sums.iter().zip(&counts) {
+        let count = (*count).max(1);
+        for channel in sum {
+            out.push((channel / count) as u8);
+        }
+    }
+
+    Thumbnail {
+        width: dst_width,
+        height: dst_height,
+        rgba: out,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::color_correction::ColorCorrection;
+    use crate::types::image::PaletteSortSettings;
+    use crate::types::qualetize::QualetizeSettings;
+
+    fn settings() -> SettingsBundle {
+        SettingsBundle::new(
+            QualetizeSettings::default(),
+            ColorCorrection::default(),
+            PaletteSortSettings::default(),
+        )
+    }
+
+    fn color(r: u8, g: u8, b: u8) -> BGRA8 {
+        BGRA8 { b, g, r, a: 255 }
+    }
+
+    /// A 4x4 image whose every pixel is index `index`, over a two color palette.
+    fn image(index: u8) -> ImageDataIndexed {
+        ImageDataIndexed::new(
+            vec![color(0, 0, 0), color(255, 255, 255)],
+            2,
+            vec![index; 16],
+        )
+    }
+
+    fn rgba(width: u32, height: u32, pixel: [u8; 4]) -> Vec<u8> {
+        pixel
+            .iter()
+            .copied()
+            .cycle()
+            .take(width as usize * height as usize * 4)
+            .collect()
+    }
+
+    fn record(results: &mut Results, indexed: &ImageDataIndexed) -> bool {
+        results.record(
+            indexed,
+            &rgba(4, 4, [10, 20, 30, 255]),
+            4,
+            4,
+            settings(),
+            Instant::now(),
+        )
+    }
+
+    #[test]
+    fn recording_the_same_image_twice_moves_it_to_the_front() {
+        let mut results = Results::default();
+        assert!(record(&mut results, &image(0)));
+        assert!(record(&mut results, &image(1)));
+        assert_eq!(results.len(), 2);
+
+        // The older of the two, recorded again, is not stored a second time.
+        assert!(!record(&mut results, &image(0)));
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results.entries()[0].hash,
+            hash_result(&image(0).indexed_pixels, &image(0).palettes)
+        );
+    }
+
+    #[test]
+    fn different_images_grow_the_list() {
+        let mut results = Results::default();
+        for index in 0..3u8 {
+            assert!(record(&mut results, &image(index)));
+        }
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn the_cap_drops_the_oldest_entry() {
+        let mut results = Results::new(3);
+        for index in 0..5u8 {
+            record(&mut results, &image(index));
+        }
+        assert_eq!(results.len(), 3);
+        // Newest first: 4, 3, 2. The first two are gone.
+        let newest = &results.entries()[0];
+        assert_eq!(newest.decode().expect("decodes").indexed_pixels[0], 4);
+        let oldest = &results.entries()[2];
+        assert_eq!(oldest.decode().expect("decodes").indexed_pixels[0], 2);
+    }
+
+    #[test]
+    fn decoding_round_trips_the_pixels() {
+        let mut results = Results::default();
+        let pixels: Vec<u8> = (0..16u8).collect();
+        let indexed = ImageDataIndexed::new(vec![color(1, 2, 3); 16], 16, pixels.clone());
+        record(&mut results, &indexed);
+
+        let decoded = results.entries()[0].decode().expect("decodes");
+        assert_eq!(decoded.indexed_pixels, pixels);
+        assert_eq!(decoded.palettes, indexed.palettes);
+        assert_eq!(decoded.colors_per_palette(), 16);
+    }
+
+    #[test]
+    fn removing_and_clearing_shrink_the_list() {
+        let mut results = Results::default();
+        for index in 0..3u8 {
+            record(&mut results, &image(index));
+        }
+        results.remove(1);
+        assert_eq!(results.len(), 2);
+        results.remove(99);
+        assert_eq!(results.len(), 2);
+        results.clear();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn a_thumbnail_keeps_the_aspect_ratio() {
+        let thumbnail = thumbnail_of(&rgba(800, 400, [0, 0, 0, 255]), 800, 400);
+        assert_eq!((thumbnail.width, thumbnail.height), (THUMBNAIL_SIZE, 80));
+        assert_eq!(
+            thumbnail.rgba.len(),
+            thumbnail.width as usize * thumbnail.height as usize * 4
+        );
+
+        let tall = thumbnail_of(&rgba(400, 800, [0, 0, 0, 255]), 400, 800);
+        assert_eq!((tall.width, tall.height), (80, THUMBNAIL_SIZE));
+    }
+
+    #[test]
+    fn a_small_image_is_not_upscaled() {
+        let source = rgba(10, 20, [1, 2, 3, 4]);
+        let thumbnail = thumbnail_of(&source, 10, 20);
+        assert_eq!((thumbnail.width, thumbnail.height), (10, 20));
+        assert_eq!(thumbnail.rgba, source);
+    }
+
+    #[test]
+    fn a_uniform_image_thumbnails_to_that_color() {
+        let pixel = [12, 34, 56, 78];
+        let thumbnail = thumbnail_of(&rgba(500, 300, pixel), 500, 300);
+        assert!(
+            thumbnail
+                .rgba
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .all(|c| *c == pixel)
+        );
+    }
+
+    #[test]
+    fn the_hash_differs_when_a_palette_entry_differs() {
+        let pixels = vec![0u8; 16];
+        let a = ImageDataIndexed::new(
+            vec![color(0, 0, 0), color(255, 255, 255)],
+            2,
+            pixels.clone(),
+        );
+        let b = ImageDataIndexed::new(vec![color(0, 0, 0), color(255, 255, 254)], 2, pixels);
+
+        assert_ne!(
+            hash_result(&a.indexed_pixels, &a.palettes),
+            hash_result(&b.indexed_pixels, &b.palettes)
+        );
+
+        let mut results = Results::default();
+        assert!(record(&mut results, &a));
+        assert!(record(&mut results, &b));
+        assert_eq!(results.len(), 2);
+    }
+}

--- a/src/types/results.rs
+++ b/src/types/results.rs
@@ -67,6 +67,62 @@ impl StoredResult {
     }
 }
 
+/// The list as it was drawn last frame, and the animation the current order
+/// started.
+#[derive(Default)]
+pub struct ResultsView {
+    /// Hashes in the order the entries were drawn in.
+    pub last_order: Vec<u64>,
+    pub animation: Option<ResultsAnimation>,
+}
+
+/// The order change being animated, and when it started.
+pub struct ResultsAnimation {
+    pub kind: ChangeKind,
+    pub started: Instant,
+}
+
+/// A change of the list order that the panel animates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    /// A result that was not in the list is now at its top.
+    Added { hash: u64 },
+    /// The result drawn at `old_index` is now at the top.
+    Moved { hash: u64, old_index: usize },
+}
+
+impl ChangeKind {
+    /// The result that reached the top.
+    pub fn hash(self) -> u64 {
+        match self {
+            Self::Added { hash } | Self::Moved { hash, old_index: _ } => hash,
+        }
+    }
+}
+
+/// How the order `now` differs from the order `last`, for the two changes the
+/// panel animates. Anything else -- a removal, an emptied list, several
+/// changes at once -- is [`None`].
+pub fn detect_change(last: &[u64], now: &[u64]) -> Option<ChangeKind> {
+    let (&hash, rest) = now.split_first()?;
+    match last.iter().position(|&other| other == hash) {
+        None if rest == last => Some(ChangeKind::Added { hash }),
+        Some(old_index) if old_index > 0 && skipping(last, old_index).eq(rest.iter()) => {
+            Some(ChangeKind::Moved { hash, old_index })
+        }
+        _ => None,
+    }
+}
+
+/// `order` without the hash at `index`.
+fn skipping(order: &[u64], index: usize) -> impl Iterator<Item = &u64> {
+    order
+        .iter()
+        .enumerate()
+        .filter(move |(at, _)| *at != index)
+        .map(|(_, hash)| hash)
+}
+
 /// The recorded results, newest first.
 pub struct Results {
     entries: Vec<StoredResult>,
@@ -376,6 +432,59 @@ mod tests {
                 .iter()
                 .all(|c| *c == pixel)
         );
+    }
+
+    #[test]
+    fn an_unchanged_order_is_no_change() {
+        assert_eq!(detect_change(&[1, 2, 3], &[1, 2, 3]), None);
+        assert_eq!(detect_change(&[], &[]), None);
+    }
+
+    #[test]
+    fn a_hash_that_is_new_at_the_top_is_an_addition() {
+        assert_eq!(
+            detect_change(&[1, 2], &[9, 1, 2]),
+            Some(ChangeKind::Added { hash: 9 })
+        );
+        assert_eq!(
+            detect_change(&[], &[9]),
+            Some(ChangeKind::Added { hash: 9 })
+        );
+    }
+
+    #[test]
+    fn a_hash_taken_from_further_down_is_a_move() {
+        assert_eq!(
+            detect_change(&[1, 2, 3, 4], &[3, 1, 2, 4]),
+            Some(ChangeKind::Moved {
+                hash: 3,
+                old_index: 2,
+            })
+        );
+        assert_eq!(
+            detect_change(&[1, 2], &[2, 1]),
+            Some(ChangeKind::Moved {
+                hash: 2,
+                old_index: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn a_removal_or_an_emptied_list_is_no_change() {
+        assert_eq!(detect_change(&[1, 2, 3], &[1, 3]), None);
+        assert_eq!(detect_change(&[1, 2, 3], &[2, 3]), None);
+        assert_eq!(detect_change(&[1, 2, 3], &[]), None);
+    }
+
+    #[test]
+    fn several_changes_at_once_are_no_change() {
+        // A new entry at the top and the oldest one dropped by the cap.
+        assert_eq!(detect_change(&[1, 2, 3], &[9, 1, 2]), None);
+        // An entry moved to the top and another one gone.
+        assert_eq!(detect_change(&[1, 2, 3], &[3, 1]), None);
+        // A reorder that is not a move to the top.
+        assert_eq!(detect_change(&[1, 2, 3], &[1, 3, 2]), None);
     }
 
     #[test]

--- a/src/types/tilepalquant.rs
+++ b/src/types/tilepalquant.rs
@@ -15,6 +15,15 @@ pub enum TpqDitherMode {
 }
 
 impl TpqDitherMode {
+    /// Matches the Dithering combo, where [`Self::Off`] is the "None" entry.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            TpqDitherMode::Off => "None",
+            TpqDitherMode::Fast => "Fast",
+            TpqDitherMode::Slow => "Slow",
+        }
+    }
+
     pub fn description(&self) -> &'static str {
         match self {
             TpqDitherMode::Off => "No dithering",

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -221,6 +221,7 @@ pub fn draw_header(ui: &mut egui::Ui, state: &mut AppState) -> (bool, bool) {
             .ui(ui, |ui| {
                 ui.label(egui::widget_text::RichText::new("Canvas").small());
                 ui.checkbox(&mut state.preferences.show_palettes, "Palettes");
+                ui.checkbox(&mut state.preferences.show_results, "Results");
 
                 ui.separator();
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod footer;
 mod header;
 mod image_viewer;
+mod results_panel;
 mod settings_panel;
 pub mod styles;
 mod widgets;
@@ -8,4 +9,5 @@ mod widgets;
 pub use footer::draw_footer;
 pub use header::draw_header;
 pub use image_viewer::{draw_image_view, draw_main_content};
+pub use results_panel::draw_results_panel;
 pub use settings_panel::draw_settings_panel;

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -42,7 +42,6 @@ struct Panel<'a> {
 pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     ui.heading_with_margin("Results");
 
-    let current = state.settings_bundle();
     let AppState {
         results,
         results_textures,
@@ -50,17 +49,8 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
         ..
     } = state;
 
-    // The result of the settings in use is on screen already, so the list
-    // holds only the others.
-    let listed: Vec<&StoredResult> = results
-        .entries()
-        .iter()
-        .filter(|entry| entry.settings != current)
-        .collect();
-    if listed.is_empty() {
-        if results.is_empty() {
-            results_textures.clear();
-        }
+    if results.is_empty() {
+        results_textures.clear();
         ui.vertical_centered(|ui| {
             ui.add_space(8.0);
             ui.label(egui::RichText::new("No results yet").small().weak());
@@ -76,7 +66,7 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     };
 
     egui::ScrollArea::vertical().show(ui, |ui| {
-        for entry in listed {
+        for entry in results.entries() {
             draw_entry(ui, entry, &mut panel);
         }
     });
@@ -156,14 +146,30 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
         ),
         Vec2::splat(REMOVE_OVERLAY_SIZE),
     );
-    // A child Ui keeps the overlay out of the parent's layout: `put` would
-    // pull the cursor back up to the overlay's bottom edge.
+    // Drawn by hand rather than as a widget so the layout cursor stays at
+    // the image's bottom edge: a translucent disc with the glyph on it.
     let remove = ui
-        .new_child(egui::UiBuilder::new().max_rect(overlay_rect).layout(
-            egui::Layout::centered_and_justified(egui::Direction::TopDown),
-        ))
-        .add(egui::Button::new("×").small().frame(false))
+        .interact(
+            overlay_rect,
+            ui.make_persistent_id(("result-remove", entry.hash)),
+            Sense::click(),
+        )
         .on_hover_text("Remove");
+    let visuals = ui.visuals();
+    let (fill, text_color) = if remove.hovered() {
+        (Color32::from_black_alpha(200), visuals.strong_text_color())
+    } else {
+        (Color32::from_black_alpha(120), visuals.text_color())
+    };
+    let painter = ui.painter();
+    painter.circle_filled(overlay_rect.center(), REMOVE_OVERLAY_SIZE / 2.0, fill);
+    painter.text(
+        overlay_rect.center(),
+        egui::Align2::CENTER_CENTER,
+        "×",
+        egui::FontId::proportional(14.0),
+        text_color,
+    );
 
     if remove.clicked() {
         _ = panel

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -159,11 +159,12 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
             Sense::click(),
         )
         .on_hover_text("Remove");
-    let visuals = ui.visuals();
+    // Fixed colors rather than the theme's: the disc sits on the image, not
+    // on the panel, so it has to read the same in both themes.
     let (fill, text_color) = if remove.hovered() {
-        (Color32::from_black_alpha(200), visuals.strong_text_color())
+        (Color32::from_black_alpha(200), Color32::WHITE)
     } else {
-        (Color32::from_black_alpha(120), visuals.text_color())
+        (Color32::from_black_alpha(120), Color32::from_gray(230))
     };
     let painter = ui.painter();
     painter.circle_filled(overlay_rect.center(), REMOVE_OVERLAY_SIZE / 2.0, fill);

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -1,7 +1,7 @@
 //! The Results side panel: the recorded outputs, newest first. Each entry
-//! shows its image, the palettes it uses and a summary of the settings that
-//! produced it, and can put those settings back in use or write the image
-//! out without re-running the pipeline.
+//! shows its image and the palettes it uses, with the full settings in a
+//! hover tooltip. Clicking the image puts those settings back in use;
+//! the overlay in its top-right corner removes the entry.
 
 use crate::engine::QuantEngine;
 use crate::settings_manager::SettingsBundle;
@@ -22,10 +22,17 @@ const SWATCH_SPACING: f32 = 1.0;
 /// Full resolution textures held at once. One costs as much memory as the
 /// image itself, so only the topmost visible rows get one.
 const MAX_FULL_TEXTURES: usize = 8;
+/// Side length of the "remove" overlay drawn over an image's top-right corner.
+const REMOVE_OVERLAY_SIZE: f32 = 18.0;
+/// Gap between the "remove" overlay and the image's top and right edges.
+const REMOVE_OVERLAY_INSET: f32 = 2.0;
+/// Vertical gap after an ordinary entry.
+const ENTRY_SPACING: f32 = 6.0;
+/// Vertical gap after the entry whose settings are the ones in use, standing
 
 /// What the entries being drawn share: the texture cache, which rows turned
-/// out to be visible, how many full resolution textures are in use, and where
-/// the buttons send their requests.
+/// out to be visible, how many full resolution textures are in use, and
+/// where clicks send their requests.
 struct Panel<'a> {
     textures: &'a mut HashMap<u64, ResultTextures>,
     visible: Vec<u64>,
@@ -44,8 +51,17 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
         ..
     } = state;
 
-    if results.is_empty() {
-        results_textures.clear();
+    // The result of the settings in use is on screen already, so the list
+    // holds only the others.
+    let listed: Vec<&StoredResult> = results
+        .entries()
+        .iter()
+        .filter(|entry| entry.settings != current)
+        .collect();
+    if listed.is_empty() {
+        if results.is_empty() {
+            results_textures.clear();
+        }
         ui.vertical_centered(|ui| {
             ui.add_space(8.0);
             ui.label(egui::RichText::new("No results yet").small().weak());
@@ -61,9 +77,8 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     };
 
     egui::ScrollArea::vertical().show(ui, |ui| {
-        for entry in results.entries() {
-            draw_entry(ui, entry, entry.settings == current, &mut panel);
-            ui.add_space(4.0);
+        for entry in listed {
+            draw_entry(ui, entry, &mut panel);
         }
     });
 
@@ -81,30 +96,17 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     });
 }
 
-/// One entry: image, palette strip, summary line and buttons, inside a frame
-/// that carries the accent stroke while its settings are the ones in use.
-fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, selected: bool, panel: &mut Panel) {
-    let mut frame = egui::Frame::group(ui.style());
-    if selected {
-        frame = frame.stroke(egui::Stroke::new(1.0, ui.visuals().selection.stroke.color));
-    }
-
-    let drawn = frame.show(ui, |ui| {
-        draw_entry_image(ui, entry, panel);
-        ui.add_space(2.0);
-        draw_palette_strip(ui, entry);
-        ui.add_space(2.0);
-        ui.label(egui::RichText::new(summary(&entry.settings)).small());
-        draw_buttons(ui, entry.hash, panel.sender)
-    });
-
-    // The buttons carry their own tooltips; the entry's would stack on top.
-    if !drawn.inner {
-        drawn.response.on_hover_text(describe(&entry.settings));
-    }
+/// One entry: image (with its palette strip below) and the remove overlay.
+fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
+    draw_entry_image(ui, entry, panel);
+    ui.add_space(2.0);
+    draw_palette_strip(ui, entry);
+    ui.add_space(ENTRY_SPACING);
 }
 
-/// The image at the panel's width, never past 1:1. The texture is only
+/// The image at the panel's width, never past 1:1, with a small "remove"
+/// overlay at its top-right corner. Clicking the image applies the entry's
+/// settings; clicking the overlay removes it instead. The texture is only
 /// uploaded once the row has scrolled into view, and the full resolution one
 /// only while the display size is past the thumbnail's.
 fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
@@ -114,7 +116,7 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
 
     let width = ui.available_width().min(entry.width as f32).max(1.0);
     let height = width * entry.height as f32 / entry.width as f32;
-    let (rect, _) = ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
+    let (rect, image_response) = ui.allocate_exact_size(Vec2::new(width, height), Sense::click());
     if !ui.is_rect_visible(rect) {
         return;
     }
@@ -147,6 +149,29 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
         Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
         Color32::WHITE,
     );
+
+    let overlay_rect = Rect::from_min_size(
+        egui::pos2(
+            rect.right() - REMOVE_OVERLAY_SIZE - REMOVE_OVERLAY_INSET,
+            rect.top() + REMOVE_OVERLAY_INSET,
+        ),
+        Vec2::splat(REMOVE_OVERLAY_SIZE),
+    );
+    let remove = ui
+        .put(overlay_rect, egui::Button::new("×").small().frame(false))
+        .on_hover_text("Remove");
+
+    if remove.clicked() {
+        _ = panel
+            .sender
+            .send(AppStateRequest::RemoveResult { hash: entry.hash });
+    } else if image_response.clicked() {
+        _ = panel
+            .sender
+            .send(AppStateRequest::ApplyResult { hash: entry.hash });
+    }
+
+    image_response.on_hover_text(describe(&entry.settings));
 }
 
 /// One row per palette, shrunk so a whole palette fits the panel width.
@@ -183,35 +208,6 @@ fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult) {
     }
 }
 
-/// Apply / Export / Remove. Returns whether one of them is hovered.
-fn draw_buttons(ui: &mut egui::Ui, hash: u64, sender: &Sender<AppStateRequest>) -> bool {
-    let mut hovered = false;
-    ui.horizontal(|ui| {
-        let apply = ui.small_button("Apply").on_hover_text("Use these settings");
-        if apply.clicked() {
-            _ = sender.send(AppStateRequest::ApplyResult { hash });
-        }
-        hovered |= apply.hovered();
-
-        let export = ui
-            .small_button("Export")
-            .on_hover_text("Export this image in the selected format");
-        if export.clicked() {
-            _ = sender.send(AppStateRequest::ExportResult { hash });
-        }
-        hovered |= export.hovered();
-
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            let remove = ui.small_button("×").on_hover_text("Remove");
-            if remove.clicked() {
-                _ = sender.send(AppStateRequest::RemoveResult { hash });
-            }
-            hovered |= remove.hovered();
-        });
-    });
-    hovered
-}
-
 /// Swatch size for `colors` swatches in one row of `width`, never above the
 /// size the main view uses.
 fn swatch_size(width: f32, colors: usize) -> f32 {
@@ -244,18 +240,6 @@ fn full_texture(ctx: &egui::Context, entry: &StoredResult) -> Option<egui::Textu
         egui::ColorImage::from_rgba_unmultiplied(size, &indexed.to_rgba()),
         TextureOptions::NEAREST,
     ))
-}
-
-/// The one line under an entry: engine, palette size and dithering.
-fn summary(settings: &SettingsBundle) -> String {
-    let qualetize = &settings.qualetize_settings;
-    format!(
-        "{} {}×{} {}",
-        settings.engine.display_name(),
-        qualetize.n_palettes,
-        qualetize.n_colors,
-        dither_name(settings),
-    )
 }
 
 /// The settings of an entry, one per line, for its tooltip.
@@ -348,27 +332,18 @@ mod tests {
         )
     }
 
+    /// The tilepalquant description names the dither mode and its pattern,
+    /// since that engine's dithering is two settings rather than one.
     #[test]
-    fn the_summary_names_the_engine_the_palette_size_and_the_dithering() {
-        let mut settings = bundle();
-        settings.qualetize_settings.n_palettes = 4;
-        settings.qualetize_settings.n_colors = 16;
-        settings.qualetize_settings.dither_mode = crate::types::DitherMode::Atkinson;
-        assert_eq!(summary(&settings), "qualetize 4×16 Atkinson");
-    }
-
-    /// The tilepalquant summary names the dither mode and its pattern, since
-    /// that engine's dithering is two settings rather than one.
-    #[test]
-    fn the_summary_of_a_tilepalquant_result_names_the_dither_pattern() {
+    fn the_description_of_a_tilepalquant_result_names_the_dither_pattern() {
         let mut settings = bundle();
         settings.engine = QuantEngine::TilePalQuant;
         settings.tpq_settings.dither_mode = TpqDitherMode::Slow;
         settings.tpq_settings.dither_pattern = DitherPattern::Horizontal4;
         assert!(
-            summary(&settings).ends_with("Slow Horizontal 4"),
+            describe(&settings).contains("Dithering: Slow Horizontal 4"),
             "{}",
-            summary(&settings)
+            describe(&settings)
         );
     }
 

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -1,0 +1,416 @@
+//! The Results side panel: the recorded outputs, newest first. Each entry
+//! shows its image, the palettes it uses and a summary of the settings that
+//! produced it, and can put those settings back in use or write the image
+//! out without re-running the pipeline.
+
+use crate::engine::QuantEngine;
+use crate::settings_manager::SettingsBundle;
+use crate::types::app_state::{AppStateRequest, ResultTextures};
+use crate::types::image::SortMode;
+use crate::types::results::{StoredResult, THUMBNAIL_SIZE};
+use crate::types::tilepalquant::TpqDitherMode;
+use crate::types::{AppState, FirstColor};
+use crate::ui::styles::UiMarginExt;
+use egui::{Color32, Rect, Sense, TextureOptions, Vec2};
+use std::collections::HashMap;
+use std::sync::mpsc::Sender;
+
+/// Largest palette swatch, matching the palette overlay of the main view.
+const SWATCH_MAX: f32 = 16.0;
+/// Gap between two swatches, matching the main view.
+const SWATCH_SPACING: f32 = 1.0;
+/// Full resolution textures held at once. One costs as much memory as the
+/// image itself, so only the topmost visible rows get one.
+const MAX_FULL_TEXTURES: usize = 8;
+
+/// What the entries being drawn share: the texture cache, which rows turned
+/// out to be visible, how many full resolution textures are in use, and where
+/// the buttons send their requests.
+struct Panel<'a> {
+    textures: &'a mut HashMap<u64, ResultTextures>,
+    visible: Vec<u64>,
+    full_textures: usize,
+    sender: &'a Sender<AppStateRequest>,
+}
+
+pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.heading_with_margin("Results");
+
+    let current = state.settings_bundle();
+    let AppState {
+        results,
+        results_textures,
+        app_state_request_sender,
+        ..
+    } = state;
+
+    if results.is_empty() {
+        results_textures.clear();
+        ui.vertical_centered(|ui| {
+            ui.add_space(8.0);
+            ui.label(egui::RichText::new("No results yet").small().weak());
+        });
+        return;
+    }
+
+    let mut panel = Panel {
+        textures: results_textures,
+        visible: Vec::new(),
+        full_textures: 0,
+        sender: app_state_request_sender,
+    };
+
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        for entry in results.entries() {
+            draw_entry(ui, entry, entry.settings == current, &mut panel);
+            ui.add_space(4.0);
+        }
+    });
+
+    let visible = panel.visible;
+    let live: std::collections::HashSet<u64> =
+        results.entries().iter().map(|entry| entry.hash).collect();
+    results_textures.retain(|hash, textures| {
+        if !live.contains(hash) {
+            return false;
+        }
+        if !visible.contains(hash) {
+            textures.full = None;
+        }
+        true
+    });
+}
+
+/// One entry: image, palette strip, summary line and buttons, inside a frame
+/// that carries the accent stroke while its settings are the ones in use.
+fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, selected: bool, panel: &mut Panel) {
+    let mut frame = egui::Frame::group(ui.style());
+    if selected {
+        frame = frame.stroke(egui::Stroke::new(1.0, ui.visuals().selection.stroke.color));
+    }
+
+    let drawn = frame.show(ui, |ui| {
+        draw_entry_image(ui, entry, panel);
+        ui.add_space(2.0);
+        draw_palette_strip(ui, entry);
+        ui.add_space(2.0);
+        ui.label(egui::RichText::new(summary(&entry.settings)).small());
+        draw_buttons(ui, entry.hash, panel.sender)
+    });
+
+    // The buttons carry their own tooltips; the entry's would stack on top.
+    if !drawn.inner {
+        drawn.response.on_hover_text(describe(&entry.settings));
+    }
+}
+
+/// The image at the panel's width, never past 1:1. The texture is only
+/// uploaded once the row has scrolled into view, and the full resolution one
+/// only while the display size is past the thumbnail's.
+fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
+    if entry.width == 0 || entry.height == 0 {
+        return;
+    }
+
+    let width = ui.available_width().min(entry.width as f32).max(1.0);
+    let height = width * entry.height as f32 / entry.width as f32;
+    let (rect, _) = ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+    panel.visible.push(entry.hash);
+
+    let wants_full = width > THUMBNAIL_SIZE as f32 && panel.full_textures < MAX_FULL_TEXTURES;
+    let ctx = ui.ctx().clone();
+    let textures = panel.textures.entry(entry.hash).or_default();
+
+    let mut handle = None;
+    if wants_full {
+        if textures.full.is_none() {
+            textures.full = full_texture(&ctx, entry);
+        }
+        if let Some(full) = &textures.full {
+            panel.full_textures += 1;
+            handle = Some(full.clone());
+        }
+    }
+    let handle = handle.unwrap_or_else(|| {
+        textures
+            .thumbnail
+            .get_or_insert_with(|| thumbnail_texture(&ctx, entry))
+            .clone()
+    });
+
+    ui.painter().image(
+        handle.id(),
+        rect,
+        Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+        Color32::WHITE,
+    );
+}
+
+/// One row per palette, shrunk so a whole palette fits the panel width.
+fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult) {
+    let per_palette = entry.colors_per_palette;
+    if per_palette == 0 || entry.palettes.is_empty() {
+        return;
+    }
+
+    let width = ui.available_width();
+    let size = swatch_size(width, per_palette);
+    let rows = entry.palettes.len().div_ceil(per_palette);
+    let step = size + SWATCH_SPACING;
+    let (rect, _) = ui.allocate_exact_size(
+        Vec2::new(width, rows as f32 * step - SWATCH_SPACING),
+        Sense::hover(),
+    );
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+
+    let painter = ui.painter();
+    for (index, color) in entry.palettes.iter().enumerate() {
+        let min = rect.min
+            + Vec2::new(
+                (index % per_palette) as f32 * step,
+                (index / per_palette) as f32 * step,
+            );
+        painter.rect_filled(
+            Rect::from_min_size(min, Vec2::splat(size)),
+            0.0,
+            Color32::from_rgba_unmultiplied(color.r, color.g, color.b, color.a),
+        );
+    }
+}
+
+/// Apply / Export / Remove. Returns whether one of them is hovered.
+fn draw_buttons(ui: &mut egui::Ui, hash: u64, sender: &Sender<AppStateRequest>) -> bool {
+    let mut hovered = false;
+    ui.horizontal(|ui| {
+        let apply = ui.small_button("Apply").on_hover_text("Use these settings");
+        if apply.clicked() {
+            _ = sender.send(AppStateRequest::ApplyResult { hash });
+        }
+        hovered |= apply.hovered();
+
+        let export = ui
+            .small_button("Export")
+            .on_hover_text("Export this image in the selected format");
+        if export.clicked() {
+            _ = sender.send(AppStateRequest::ExportResult { hash });
+        }
+        hovered |= export.hovered();
+
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let remove = ui.small_button("×").on_hover_text("Remove");
+            if remove.clicked() {
+                _ = sender.send(AppStateRequest::RemoveResult { hash });
+            }
+            hovered |= remove.hovered();
+        });
+    });
+    hovered
+}
+
+/// Swatch size for `colors` swatches in one row of `width`, never above the
+/// size the main view uses.
+fn swatch_size(width: f32, colors: usize) -> f32 {
+    let colors = colors.max(1) as f32;
+    let by_width = (width - (colors - 1.0) * SWATCH_SPACING) / colors;
+    SWATCH_MAX.min(by_width).max(1.0)
+}
+
+fn thumbnail_texture(ctx: &egui::Context, entry: &StoredResult) -> egui::TextureHandle {
+    let thumbnail = &entry.thumbnail;
+    let size = [thumbnail.width as usize, thumbnail.height as usize];
+    ctx.load_texture(
+        format!("result-thumb-{:016x}", entry.hash),
+        egui::ColorImage::from_rgba_unmultiplied(size, &thumbnail.rgba),
+        TextureOptions::NEAREST,
+    )
+}
+
+fn full_texture(ctx: &egui::Context, entry: &StoredResult) -> Option<egui::TextureHandle> {
+    let indexed = match entry.decode() {
+        Ok(indexed) => indexed,
+        Err(e) => {
+            log::error!("Failed to decode a stored result: {e}");
+            return None;
+        }
+    };
+    let size = [entry.width as usize, entry.height as usize];
+    Some(ctx.load_texture(
+        format!("result-full-{:016x}", entry.hash),
+        egui::ColorImage::from_rgba_unmultiplied(size, &indexed.to_rgba()),
+        TextureOptions::NEAREST,
+    ))
+}
+
+/// The one line under an entry: engine, palette size and dithering.
+fn summary(settings: &SettingsBundle) -> String {
+    let qualetize = &settings.qualetize_settings;
+    format!(
+        "{} {}×{} {}",
+        settings.engine.display_name(),
+        qualetize.n_palettes,
+        qualetize.n_colors,
+        dither_name(settings),
+    )
+}
+
+/// The settings of an entry, one per line, for its tooltip.
+fn describe(settings: &SettingsBundle) -> String {
+    let qualetize = &settings.qualetize_settings;
+    let mut lines = vec![
+        settings.engine.display_name().to_string(),
+        format!(
+            "{} palettes × {} colors",
+            qualetize.n_palettes, qualetize.n_colors
+        ),
+        format!(
+            "Tile size: {}×{}",
+            qualetize.tile_width, qualetize.tile_height
+        ),
+        format!(
+            "Palette index 0: {}",
+            first_color_name(qualetize.first_color())
+        ),
+        format!("Dithering: {}", dither_name(settings)),
+        format!(
+            "Color correction: {}",
+            on_off(settings.color_correction.enabled)
+        ),
+    ];
+    lines.push(if qualetize.tile_reduce_post_enabled {
+        format!(
+            "Tile reduction: on, threshold {:.1}",
+            qualetize.tile_reduce_post_threshold
+        )
+    } else {
+        "Tile reduction: off".to_string()
+    });
+    lines.push(match settings.sort_settings.mode {
+        SortMode::None => "Palette order: off".to_string(),
+        mode => format!(
+            "Palette order: {}, {}",
+            mode.display_name(),
+            settings.sort_settings.order.display_name().to_lowercase()
+        ),
+    });
+    lines.join("\n")
+}
+
+/// The dithering of whichever engine the entry used.
+fn dither_name(settings: &SettingsBundle) -> String {
+    match settings.engine {
+        QuantEngine::Qualetize => settings
+            .qualetize_settings
+            .dither_mode
+            .display_name()
+            .to_string(),
+        QuantEngine::TilePalQuant => match settings.tpq_settings.dither_mode {
+            TpqDitherMode::Off => TpqDitherMode::Off.display_name().to_string(),
+            mode => format!(
+                "{} {}",
+                mode.display_name(),
+                settings.tpq_settings.dither_pattern.display_name()
+            ),
+        },
+    }
+}
+
+fn first_color_name(first_color: FirstColor) -> &'static str {
+    match first_color {
+        FirstColor::Unique => "Unique",
+        FirstColor::Shared => "Shared color",
+        FirstColor::TransparentFromAlpha => "Transparent, from alpha",
+        FirstColor::TransparentFromColor => "Transparent, from color",
+    }
+}
+
+fn on_off(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::color_correction::ColorCorrection;
+    use crate::types::image::PaletteSortSettings;
+    use crate::types::qualetize::QualetizeSettings;
+    use crate::types::tilepalquant::DitherPattern;
+
+    fn bundle() -> SettingsBundle {
+        SettingsBundle::new(
+            QualetizeSettings::default(),
+            ColorCorrection::default(),
+            PaletteSortSettings::default(),
+        )
+    }
+
+    #[test]
+    fn the_summary_names_the_engine_the_palette_size_and_the_dithering() {
+        let mut settings = bundle();
+        settings.qualetize_settings.n_palettes = 4;
+        settings.qualetize_settings.n_colors = 16;
+        settings.qualetize_settings.dither_mode = crate::types::DitherMode::Atkinson;
+        assert_eq!(summary(&settings), "qualetize 4×16 Atkinson");
+    }
+
+    /// The tilepalquant summary names the dither mode and its pattern, since
+    /// that engine's dithering is two settings rather than one.
+    #[test]
+    fn the_summary_of_a_tilepalquant_result_names_the_dither_pattern() {
+        let mut settings = bundle();
+        settings.engine = QuantEngine::TilePalQuant;
+        settings.tpq_settings.dither_mode = TpqDitherMode::Slow;
+        settings.tpq_settings.dither_pattern = DitherPattern::Horizontal4;
+        assert!(
+            summary(&settings).ends_with("Slow Horizontal 4"),
+            "{}",
+            summary(&settings)
+        );
+    }
+
+    #[test]
+    fn the_description_lists_the_tile_size_and_the_tile_reduction_threshold() {
+        let mut settings = bundle();
+        settings.qualetize_settings.tile_width = 8;
+        settings.qualetize_settings.tile_height = 16;
+        settings.qualetize_settings.tile_reduce_post_enabled = true;
+        settings.qualetize_settings.tile_reduce_post_threshold = 12.5;
+
+        let described = describe(&settings);
+        let lines: Vec<&str> = described.lines().collect();
+        assert!(lines.contains(&"Tile size: 8×16"), "{lines:?}");
+        assert!(
+            lines.contains(&"Tile reduction: on, threshold 12.5"),
+            "{lines:?}"
+        );
+    }
+
+    #[test]
+    fn the_description_reports_a_disabled_palette_order_as_off() {
+        let mut settings = bundle();
+        settings.sort_settings.mode = SortMode::None;
+        assert!(
+            describe(&settings)
+                .lines()
+                .any(|l| l == "Palette order: off")
+        );
+    }
+
+    /// Swatches shrink to fit a narrow panel and never grow past the size the
+    /// main view uses.
+    #[test]
+    fn swatches_fit_the_panel_width_without_growing_past_the_maximum() {
+        assert_eq!(swatch_size(1000.0, 16), SWATCH_MAX);
+
+        let size = swatch_size(120.0, 16);
+        assert!(size < SWATCH_MAX, "{size}");
+        assert!(
+            16.0 * size + 15.0 * SWATCH_SPACING <= 120.0 + 1e-3,
+            "{size}"
+        );
+    }
+}

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -114,27 +114,29 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
         sender: app_state_request_sender,
     };
 
-    egui::ScrollArea::vertical().show(ui, |ui| {
-        // Every entry takes exactly its `entry_height`, so an animated slot
-        // and the entry it stands for occupy the same space.
-        ui.spacing_mut().item_spacing.y = 0.0;
-        match animation {
-            Some((animation, elapsed)) => {
-                let width = ui.available_width();
-                draw_animated(ui, results.entries(), &mut panel, animation, elapsed, width);
-            }
-            None => {
-                for entry in results.entries() {
-                    let interaction = if entry.settings.matches(&in_use) {
-                        Interaction::RemoveOnly
-                    } else {
-                        Interaction::Apply
-                    };
-                    draw_entry(ui, entry, &mut panel, 1.0, interaction);
+    egui::ScrollArea::vertical()
+        .auto_shrink([false, false])
+        .show(ui, |ui| {
+            // Every entry takes exactly its `entry_height`, so an animated slot
+            // and the entry it stands for occupy the same space.
+            ui.spacing_mut().item_spacing.y = 0.0;
+            match animation {
+                Some((animation, elapsed)) => {
+                    let width = ui.available_width();
+                    draw_animated(ui, results.entries(), &mut panel, animation, elapsed, width);
+                }
+                None => {
+                    for entry in results.entries() {
+                        let interaction = if entry.settings.matches(&in_use) {
+                            Interaction::RemoveOnly
+                        } else {
+                            Interaction::Apply
+                        };
+                        draw_entry(ui, entry, &mut panel, 1.0, interaction);
+                    }
                 }
             }
-        }
-    });
+        });
 
     if animation.is_some() {
         ui.ctx().request_repaint();
@@ -268,7 +270,6 @@ fn image_size(entry: &StoredResult, width: f32) -> Vec2 {
 /// The height of the palette strip of `entry` in a panel `width` wide, the
 /// gaps between its rows included.
 fn strip_height(entry: &StoredResult, width: f32) -> f32 {
-    let width = image_size(entry, width).x;
     let per_palette = entry.colors_per_palette;
     if per_palette == 0 || entry.palettes.is_empty() {
         return 0.0;
@@ -294,21 +295,26 @@ fn draw_entry_image(
     alpha: f32,
     interaction: Interaction,
 ) {
-    let size = image_size(entry, ui.available_width());
+    let row_width = ui.available_width();
+    let size = image_size(entry, row_width);
     if size == Vec2::ZERO {
         return;
     }
 
+    // The row spans the panel whatever the image's width, so the image
+    // never dictates the panel's size; a narrower image is centered in it.
+    let (row, _) = ui.allocate_exact_size(Vec2::new(row_width, size.y), Sense::hover());
+    if !ui.is_rect_visible(row) {
+        return;
+    }
+    panel.visible.push(entry.hash);
+    let rect = Rect::from_center_size(row.center(), size);
     let sense = if interaction == Interaction::Apply {
         Sense::click()
     } else {
         Sense::hover()
     };
-    let (rect, image_response) = ui.allocate_exact_size(size, sense);
-    if !ui.is_rect_visible(rect) {
-        return;
-    }
-    panel.visible.push(entry.hash);
+    let image_response = ui.interact(rect, ui.make_persistent_id(("result", entry.hash)), sense);
 
     let wants_full = size.x > THUMBNAIL_SIZE as f32 && panel.full_textures < MAX_FULL_TEXTURES;
     let ctx = ui.ctx().clone();
@@ -392,10 +398,8 @@ fn draw_remove_overlay(ui: &mut egui::Ui, entry: &StoredResult, image: Rect) -> 
 
 /// One row per palette, shrunk so a whole palette fits the panel width.
 fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult, alpha: f32) {
-    let panel_width = ui.available_width();
-    let height = strip_height(entry, panel_width);
-    // As wide as the image above it.
-    let width = image_size(entry, panel_width).x;
+    let width = ui.available_width();
+    let height = strip_height(entry, width);
     if height <= 0.0 {
         return;
     }
@@ -646,16 +650,14 @@ mod tests {
         assert!((entry_height(entry, 40.0) - (20.0 + 1.0 + strip + ENTRY_SPACING)).abs() < 1e-4);
     }
 
-    /// A tall image stops at the height cap, and its strip is as wide as it.
+    /// A tall image stops at the height cap; its strip still spans the panel.
     #[test]
     fn a_tall_image_is_capped_in_height() {
         let results = recorded(64, 640, 16, 8);
         let entry = &results.entries()[0];
         let size = image_size(entry, 200.0);
         assert_eq!((size.x, size.y), (32.0, MAX_IMAGE_HEIGHT));
-        let swatch = (32.0 - 7.0 * SWATCH_SPACING) / 8.0;
-        let strip = 2.0 * (swatch + SWATCH_SPACING) - SWATCH_SPACING;
-        assert!((strip_height(entry, 200.0) - strip).abs() < 1e-4);
+        assert!((strip_height(entry, 200.0) - 33.0).abs() < 1e-4);
     }
 
     /// Swatches shrink to fit a narrow panel and never grow past the size the

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -35,6 +35,9 @@ const REMOVE_OVERLAY_SIZE: f32 = 18.0;
 const REMOVE_OVERLAY_INSET: f32 = 2.0;
 /// Gap between an image and its palette strip.
 const IMAGE_STRIP_GAP: f32 = 1.0;
+/// Tallest an entry's image is drawn: a tall image is shrunk to this, and a
+/// widened panel enlarges an image no further than this.
+const MAX_IMAGE_HEIGHT: f32 = 320.0;
 /// Vertical gap after an entry. The list drops the item spacing between its
 /// entries, so this is the whole gap.
 const ENTRY_SPACING: f32 = 9.0;
@@ -247,18 +250,25 @@ fn draw_entry(
 }
 
 /// The size the image of `entry` is drawn at in a panel `width` wide: the full
-/// width, never past 1:1.
+/// width, unless that would make it taller than [`MAX_IMAGE_HEIGHT`].
 fn image_size(entry: &StoredResult, width: f32) -> Vec2 {
     if entry.width == 0 || entry.height == 0 {
         return Vec2::ZERO;
     }
-    let width = width.min(entry.width as f32).max(1.0);
-    Vec2::new(width, width * entry.height as f32 / entry.width as f32)
+    let aspect = entry.height as f32 / entry.width as f32;
+    let width = width.max(1.0);
+    let height = width * aspect;
+    if height > MAX_IMAGE_HEIGHT {
+        Vec2::new(MAX_IMAGE_HEIGHT / aspect, MAX_IMAGE_HEIGHT)
+    } else {
+        Vec2::new(width, height)
+    }
 }
 
 /// The height of the palette strip of `entry` in a panel `width` wide, the
 /// gaps between its rows included.
 fn strip_height(entry: &StoredResult, width: f32) -> f32 {
+    let width = image_size(entry, width).x;
     let per_palette = entry.colors_per_palette;
     if per_palette == 0 || entry.palettes.is_empty() {
         return 0.0;
@@ -272,7 +282,7 @@ fn entry_height(entry: &StoredResult, width: f32) -> f32 {
     image_size(entry, width).y + IMAGE_STRIP_GAP + strip_height(entry, width) + ENTRY_SPACING
 }
 
-/// The image at the panel's width, never past 1:1, with a small "remove"
+/// The image at the panel's width, capped in height, with a small "remove"
 /// overlay at its top-right corner. Clicking the image applies the entry's
 /// settings; clicking the overlay removes it instead. The texture is only
 /// uploaded once the row has scrolled into view, and the full resolution one
@@ -382,8 +392,10 @@ fn draw_remove_overlay(ui: &mut egui::Ui, entry: &StoredResult, image: Rect) -> 
 
 /// One row per palette, shrunk so a whole palette fits the panel width.
 fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult, alpha: f32) {
-    let width = ui.available_width();
-    let height = strip_height(entry, width);
+    let panel_width = ui.available_width();
+    let height = strip_height(entry, panel_width);
+    // As wide as the image above it.
+    let width = image_size(entry, panel_width).x;
     if height <= 0.0 {
         return;
     }

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -87,9 +87,13 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
 
 /// One entry: image (with its palette strip below) and the remove overlay.
 fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
-    draw_entry_image(ui, entry, panel);
-    ui.add_space(2.0);
-    draw_palette_strip(ui, entry);
+    ui.scope(|ui| {
+        // Exactly one point between the image and its palette strip.
+        ui.spacing_mut().item_spacing.y = 0.0;
+        draw_entry_image(ui, entry, panel);
+        ui.add_space(1.0);
+        draw_palette_strip(ui, entry);
+    });
     ui.add_space(ENTRY_SPACING);
 }
 

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -2,18 +2,25 @@
 //! shows its image and the palettes it uses, with the full settings in a
 //! hover tooltip. Clicking the image puts those settings back in use;
 //! the overlay in its top-right corner removes the entry.
+//!
+//! A result reaching the top of the list is animated: the space for it opens
+//! up first, then it fades in.
 
 use crate::engine::QuantEngine;
 use crate::settings_manager::SettingsBundle;
+use crate::time::Instant;
 use crate::types::app_state::{AppStateRequest, ResultTextures};
 use crate::types::image::SortMode;
-use crate::types::results::{StoredResult, THUMBNAIL_SIZE};
+use crate::types::results::{
+    ChangeKind, ResultsAnimation, StoredResult, THUMBNAIL_SIZE, detect_change,
+};
 use crate::types::tilepalquant::TpqDitherMode;
 use crate::types::{AppState, FirstColor};
 use crate::ui::styles::UiMarginExt;
-use egui::{Color32, Rect, Sense, TextureOptions, Vec2};
+use egui::{Align, Color32, Layout, Rect, Sense, TextureOptions, UiBuilder, Vec2};
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
+use std::time::Duration;
 
 /// Largest palette swatch, matching the palette overlay of the main view.
 const SWATCH_MAX: f32 = 16.0;
@@ -26,8 +33,14 @@ const MAX_FULL_TEXTURES: usize = 8;
 const REMOVE_OVERLAY_SIZE: f32 = 18.0;
 /// Gap between the "remove" overlay and the image's top and right edges.
 const REMOVE_OVERLAY_INSET: f32 = 2.0;
-/// Vertical gap after an entry.
-const ENTRY_SPACING: f32 = 6.0;
+/// Gap between an image and its palette strip.
+const IMAGE_STRIP_GAP: f32 = 1.0;
+/// Vertical gap after an entry. The list drops the item spacing between its
+/// entries, so this is the whole gap.
+const ENTRY_SPACING: f32 = 9.0;
+/// Length of each of the two phases of an order change: the slots resize,
+/// then the entry that reached the top fades in.
+const ANIM_PHASE: Duration = Duration::from_millis(300);
 
 /// What the entries being drawn share: the texture cache, which rows turned
 /// out to be visible, how many full resolution textures are in use, and
@@ -39,24 +52,57 @@ struct Panel<'a> {
     sender: &'a Sender<AppStateRequest>,
 }
 
+/// What an entry reacts to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Interaction {
+    /// Clicking the image applies the entry's settings, the overlay removes it.
+    Apply,
+    /// The entry's settings are the ones in use, so only the overlay reacts.
+    RemoveOnly,
+    /// Nothing reacts.
+    Inert,
+}
+
 pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     ui.heading_with_margin("Results");
 
+    let in_use = state.settings_bundle();
     let AppState {
         results,
         results_textures,
+        results_view,
         app_state_request_sender,
         ..
     } = state;
 
     if results.is_empty() {
         results_textures.clear();
+        results_view.last_order.clear();
+        results_view.animation = None;
         ui.vertical_centered(|ui| {
             ui.add_space(8.0);
             ui.label(egui::RichText::new("No results yet").small().weak());
         });
         return;
     }
+
+    let order: Vec<u64> = results.entries().iter().map(|entry| entry.hash).collect();
+    if order != results_view.last_order {
+        results_view.animation =
+            detect_change(&results_view.last_order, &order).map(|kind| ResultsAnimation {
+                kind,
+                started: Instant::now(),
+            });
+        results_view.last_order = order;
+    }
+    // An animation describes the current list only while the entry it moves
+    // is at the top of it.
+    let animation = results_view.animation.as_ref().and_then(|animation| {
+        let elapsed = animation.started.elapsed().as_secs_f32();
+        let at_top =
+            results.entries().first().map(|entry| entry.hash) == Some(animation.kind.hash());
+        (at_top && elapsed < 2.0 * ANIM_PHASE.as_secs_f32()).then_some((animation, elapsed))
+    });
 
     let mut panel = Panel {
         textures: results_textures,
@@ -66,10 +112,32 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     };
 
     egui::ScrollArea::vertical().show(ui, |ui| {
-        for entry in results.entries() {
-            draw_entry(ui, entry, &mut panel);
+        // Every entry takes exactly its `entry_height`, so an animated slot
+        // and the entry it stands for occupy the same space.
+        ui.spacing_mut().item_spacing.y = 0.0;
+        match animation {
+            Some((animation, elapsed)) => {
+                let width = ui.available_width();
+                draw_animated(ui, results.entries(), &mut panel, animation, elapsed, width);
+            }
+            None => {
+                for entry in results.entries() {
+                    let interaction = if entry.settings.matches(&in_use) {
+                        Interaction::RemoveOnly
+                    } else {
+                        Interaction::Apply
+                    };
+                    draw_entry(ui, entry, &mut panel, 1.0, interaction);
+                }
+            }
         }
     });
+
+    if animation.is_some() {
+        ui.ctx().request_repaint();
+    } else {
+        results_view.animation = None;
+    }
 
     let visible = panel.visible;
     let live: std::collections::HashSet<u64> =
@@ -85,16 +153,123 @@ pub fn draw_results_panel(ui: &mut egui::Ui, state: &mut AppState) {
     });
 }
 
+/// The list while its order animates. The entry that reached the top gets a
+/// slot of its own there; the others are drawn in the order they had before,
+/// and no entry reacts to the pointer.
+///
+/// In the first phase the top slot grows from nothing, which pushes the
+/// entries below it down; the entry that moved shrinks away at the place it
+/// held, so the entries under that place stay where they are. In the second
+/// phase the entry fades in inside the top slot.
+fn draw_animated(
+    ui: &mut egui::Ui,
+    entries: &[StoredResult],
+    panel: &mut Panel,
+    animation: &ResultsAnimation,
+    elapsed: f32,
+    width: f32,
+) {
+    let Some((moved, rest)) = entries.split_first() else {
+        return;
+    };
+    let phase = ANIM_PHASE.as_secs_f32();
+    let height = entry_height(moved, width);
+
+    if elapsed >= phase {
+        let alpha = (elapsed - phase) / phase;
+        slot(ui, width, height, |ui| {
+            draw_entry(ui, moved, panel, alpha, Interaction::Inert);
+        });
+        for entry in rest {
+            draw_entry(ui, entry, panel, 1.0, Interaction::Inert);
+        }
+        return;
+    }
+
+    let progress = elapsed / phase;
+    let opened = ease_out(progress);
+    slot(ui, width, height * opened, |_| {});
+    let old_index = match animation.kind {
+        ChangeKind::Added { hash: _ } => None,
+        ChangeKind::Moved { hash: _, old_index } => Some(old_index.min(rest.len())),
+    };
+    for index in 0..=rest.len() {
+        if old_index == Some(index) {
+            slot(ui, width, height * (1.0 - opened), |ui| {
+                draw_entry(ui, moved, panel, 1.0 - progress, Interaction::Inert);
+            });
+        }
+        if let Some(entry) = rest.get(index) {
+            draw_entry(ui, entry, panel, 1.0, Interaction::Inert);
+        }
+    }
+}
+
+/// Draw `add` in a slot of exactly `height`, clipped to it, so an entry taller
+/// than its slot is cut off instead of pushing the next one down.
+fn slot(ui: &mut egui::Ui, width: f32, height: f32, add: impl FnOnce(&mut egui::Ui)) {
+    if height <= 0.0 {
+        return;
+    }
+    let (rect, _) = ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
+    let clip = rect.intersect(ui.clip_rect());
+    let mut inner = ui.new_child(
+        UiBuilder::new()
+            .max_rect(rect)
+            .layout(Layout::top_down(Align::Min)),
+    );
+    inner.set_clip_rect(clip);
+    add(&mut inner);
+}
+
+/// Ease-out cubic.
+fn ease_out(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    1.0 - (1.0 - t).powi(3)
+}
+
 /// One entry: image (with its palette strip below) and the remove overlay.
-fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
+fn draw_entry(
+    ui: &mut egui::Ui,
+    entry: &StoredResult,
+    panel: &mut Panel,
+    alpha: f32,
+    interaction: Interaction,
+) {
     ui.scope(|ui| {
         // Exactly one point between the image and its palette strip.
         ui.spacing_mut().item_spacing.y = 0.0;
-        draw_entry_image(ui, entry, panel);
-        ui.add_space(1.0);
-        draw_palette_strip(ui, entry);
+        draw_entry_image(ui, entry, panel, alpha, interaction);
+        ui.add_space(IMAGE_STRIP_GAP);
+        draw_palette_strip(ui, entry, alpha);
     });
     ui.add_space(ENTRY_SPACING);
+}
+
+/// The size the image of `entry` is drawn at in a panel `width` wide: the full
+/// width, never past 1:1.
+fn image_size(entry: &StoredResult, width: f32) -> Vec2 {
+    if entry.width == 0 || entry.height == 0 {
+        return Vec2::ZERO;
+    }
+    let width = width.min(entry.width as f32).max(1.0);
+    Vec2::new(width, width * entry.height as f32 / entry.width as f32)
+}
+
+/// The height of the palette strip of `entry` in a panel `width` wide, the
+/// gaps between its rows included.
+fn strip_height(entry: &StoredResult, width: f32) -> f32 {
+    let per_palette = entry.colors_per_palette;
+    if per_palette == 0 || entry.palettes.is_empty() {
+        return 0.0;
+    }
+    let rows = entry.palettes.len().div_ceil(per_palette) as f32;
+    rows * (swatch_size(width, per_palette) + SWATCH_SPACING) - SWATCH_SPACING
+}
+
+/// The vertical space [`draw_entry`] takes in a panel `width` wide.
+fn entry_height(entry: &StoredResult, width: f32) -> f32 {
+    image_size(entry, width).y + IMAGE_STRIP_GAP + strip_height(entry, width) + ENTRY_SPACING
 }
 
 /// The image at the panel's width, never past 1:1, with a small "remove"
@@ -102,20 +277,30 @@ fn draw_entry(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
 /// settings; clicking the overlay removes it instead. The texture is only
 /// uploaded once the row has scrolled into view, and the full resolution one
 /// only while the display size is past the thumbnail's.
-fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) {
-    if entry.width == 0 || entry.height == 0 {
+fn draw_entry_image(
+    ui: &mut egui::Ui,
+    entry: &StoredResult,
+    panel: &mut Panel,
+    alpha: f32,
+    interaction: Interaction,
+) {
+    let size = image_size(entry, ui.available_width());
+    if size == Vec2::ZERO {
         return;
     }
 
-    let width = ui.available_width().min(entry.width as f32).max(1.0);
-    let height = width * entry.height as f32 / entry.width as f32;
-    let (rect, image_response) = ui.allocate_exact_size(Vec2::new(width, height), Sense::click());
+    let sense = if interaction == Interaction::Apply {
+        Sense::click()
+    } else {
+        Sense::hover()
+    };
+    let (rect, image_response) = ui.allocate_exact_size(size, sense);
     if !ui.is_rect_visible(rect) {
         return;
     }
     panel.visible.push(entry.hash);
 
-    let wants_full = width > THUMBNAIL_SIZE as f32 && panel.full_textures < MAX_FULL_TEXTURES;
+    let wants_full = size.x > THUMBNAIL_SIZE as f32 && panel.full_textures < MAX_FULL_TEXTURES;
     let ctx = ui.ctx().clone();
     let textures = panel.textures.entry(entry.hash).or_default();
 
@@ -140,13 +325,30 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
         handle.id(),
         rect,
         Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
-        Color32::WHITE,
+        Color32::WHITE.gamma_multiply(alpha),
     );
 
+    let removed = interaction != Interaction::Inert && draw_remove_overlay(ui, entry, rect);
+    if removed {
+        _ = panel
+            .sender
+            .send(AppStateRequest::RemoveResult { hash: entry.hash });
+    } else if image_response.clicked() {
+        _ = panel
+            .sender
+            .send(AppStateRequest::ApplyResult { hash: entry.hash });
+    }
+
+    image_response.on_hover_text(describe(&entry.settings));
+}
+
+/// The "remove" overlay over the top-right corner of `image`, `true` when it
+/// was clicked.
+fn draw_remove_overlay(ui: &mut egui::Ui, entry: &StoredResult, image: Rect) -> bool {
     let overlay_rect = Rect::from_min_size(
         egui::pos2(
-            rect.right() - REMOVE_OVERLAY_SIZE - REMOVE_OVERLAY_INSET,
-            rect.top() + REMOVE_OVERLAY_INSET,
+            image.right() - REMOVE_OVERLAY_SIZE - REMOVE_OVERLAY_INSET,
+            image.top() + REMOVE_OVERLAY_INSET,
         ),
         Vec2::splat(REMOVE_OVERLAY_SIZE),
     );
@@ -175,35 +377,21 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
         egui::FontId::proportional(14.0),
         text_color,
     );
-
-    if remove.clicked() {
-        _ = panel
-            .sender
-            .send(AppStateRequest::RemoveResult { hash: entry.hash });
-    } else if image_response.clicked() {
-        _ = panel
-            .sender
-            .send(AppStateRequest::ApplyResult { hash: entry.hash });
-    }
-
-    image_response.on_hover_text(describe(&entry.settings));
+    remove.clicked()
 }
 
 /// One row per palette, shrunk so a whole palette fits the panel width.
-fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult) {
-    let per_palette = entry.colors_per_palette;
-    if per_palette == 0 || entry.palettes.is_empty() {
+fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult, alpha: f32) {
+    let width = ui.available_width();
+    let height = strip_height(entry, width);
+    if height <= 0.0 {
         return;
     }
 
-    let width = ui.available_width();
+    let per_palette = entry.colors_per_palette;
     let size = swatch_size(width, per_palette);
-    let rows = entry.palettes.len().div_ceil(per_palette);
     let step = size + SWATCH_SPACING;
-    let (rect, _) = ui.allocate_exact_size(
-        Vec2::new(width, rows as f32 * step - SWATCH_SPACING),
-        Sense::hover(),
-    );
+    let (rect, _) = ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
     if !ui.is_rect_visible(rect) {
         return;
     }
@@ -218,7 +406,8 @@ fn draw_palette_strip(ui: &mut egui::Ui, entry: &StoredResult) {
         painter.rect_filled(
             Rect::from_min_size(min, Vec2::splat(size)),
             0.0,
-            Color32::from_rgba_unmultiplied(color.r, color.g, color.b, color.a),
+            Color32::from_rgba_unmultiplied(color.r, color.g, color.b, color.a)
+                .gamma_multiply(alpha),
         );
     }
 }
@@ -334,9 +523,11 @@ fn on_off(enabled: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::BGRA8;
     use crate::types::color_correction::ColorCorrection;
-    use crate::types::image::PaletteSortSettings;
+    use crate::types::image::{ImageDataIndexed, PaletteSortSettings};
     use crate::types::qualetize::QualetizeSettings;
+    use crate::types::results::Results;
     use crate::types::tilepalquant::DitherPattern;
 
     fn bundle() -> SettingsBundle {
@@ -388,6 +579,59 @@ mod tests {
                 .lines()
                 .any(|l| l == "Palette order: off")
         );
+    }
+
+    /// One recorded result of `width`x`height` over a palette of `colors`
+    /// colors laid out `per_palette` to a row.
+    fn recorded(width: u32, height: u32, colors: usize, per_palette: usize) -> Results {
+        let pixels = width as usize * height as usize;
+        let indexed = ImageDataIndexed::new(
+            vec![
+                BGRA8 {
+                    b: 0,
+                    g: 0,
+                    r: 0,
+                    a: 255,
+                };
+                colors
+            ],
+            per_palette,
+            vec![0; pixels],
+        );
+        let mut results = Results::default();
+        results.record(
+            &indexed,
+            &vec![0; pixels * 4],
+            width,
+            height,
+            bundle(),
+            Instant::now(),
+        );
+        results
+    }
+
+    /// The height an entry is given is the height it takes: its image, the
+    /// gap, its palette strip and the spacing after it.
+    #[test]
+    fn an_entry_is_as_tall_as_the_parts_it_is_drawn_from() {
+        let results = recorded(64, 32, 16, 8);
+        let entry = &results.entries()[0];
+
+        for width in [200.0, 40.0] {
+            let parts = image_size(entry, width).y
+                + IMAGE_STRIP_GAP
+                + strip_height(entry, width)
+                + ENTRY_SPACING;
+            assert!((entry_height(entry, width) - parts).abs() < 1e-4, "{width}");
+        }
+
+        // 64 points wide in a 200 point panel: 1:1, so 32 points tall. Two
+        // rows of 8 swatches at the largest size: 2 * (16 + 1) - 1 = 33.
+        assert!((entry_height(entry, 200.0) - (32.0 + 1.0 + 33.0 + ENTRY_SPACING)).abs() < 1e-4);
+        // Narrower than the image: half the size, with swatches shrunk to fit.
+        let swatch = (40.0 - 7.0 * SWATCH_SPACING) / 8.0;
+        let strip = 2.0 * (swatch + SWATCH_SPACING) - SWATCH_SPACING;
+        assert!((entry_height(entry, 40.0) - (20.0 + 1.0 + strip + ENTRY_SPACING)).abs() < 1e-4);
     }
 
     /// Swatches shrink to fit a narrow panel and never grow past the size the

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -637,13 +637,25 @@ mod tests {
             assert!((entry_height(entry, width) - parts).abs() < 1e-4, "{width}");
         }
 
-        // 64 points wide in a 200 point panel: 1:1, so 32 points tall. Two
-        // rows of 8 swatches at the largest size: 2 * (16 + 1) - 1 = 33.
-        assert!((entry_height(entry, 200.0) - (32.0 + 1.0 + 33.0 + ENTRY_SPACING)).abs() < 1e-4);
+        // The image fills a 200 point panel: 200 x 100. Two rows of 8
+        // swatches at the largest size: 2 * (16 + 1) - 1 = 33.
+        assert!((entry_height(entry, 200.0) - (100.0 + 1.0 + 33.0 + ENTRY_SPACING)).abs() < 1e-4);
         // Narrower than the image: half the size, with swatches shrunk to fit.
         let swatch = (40.0 - 7.0 * SWATCH_SPACING) / 8.0;
         let strip = 2.0 * (swatch + SWATCH_SPACING) - SWATCH_SPACING;
         assert!((entry_height(entry, 40.0) - (20.0 + 1.0 + strip + ENTRY_SPACING)).abs() < 1e-4);
+    }
+
+    /// A tall image stops at the height cap, and its strip is as wide as it.
+    #[test]
+    fn a_tall_image_is_capped_in_height() {
+        let results = recorded(64, 640, 16, 8);
+        let entry = &results.entries()[0];
+        let size = image_size(entry, 200.0);
+        assert_eq!((size.x, size.y), (32.0, MAX_IMAGE_HEIGHT));
+        let swatch = (32.0 - 7.0 * SWATCH_SPACING) / 8.0;
+        let strip = 2.0 * (swatch + SWATCH_SPACING) - SWATCH_SPACING;
+        assert!((strip_height(entry, 200.0) - strip).abs() < 1e-4);
     }
 
     /// Swatches shrink to fit a narrow panel and never grow past the size the

--- a/src/ui/results_panel.rs
+++ b/src/ui/results_panel.rs
@@ -26,9 +26,8 @@ const MAX_FULL_TEXTURES: usize = 8;
 const REMOVE_OVERLAY_SIZE: f32 = 18.0;
 /// Gap between the "remove" overlay and the image's top and right edges.
 const REMOVE_OVERLAY_INSET: f32 = 2.0;
-/// Vertical gap after an ordinary entry.
+/// Vertical gap after an entry.
 const ENTRY_SPACING: f32 = 6.0;
-/// Vertical gap after the entry whose settings are the ones in use, standing
 
 /// What the entries being drawn share: the texture cache, which rows turned
 /// out to be visible, how many full resolution textures are in use, and
@@ -157,8 +156,13 @@ fn draw_entry_image(ui: &mut egui::Ui, entry: &StoredResult, panel: &mut Panel) 
         ),
         Vec2::splat(REMOVE_OVERLAY_SIZE),
     );
+    // A child Ui keeps the overlay out of the parent's layout: `put` would
+    // pull the cursor back up to the overlay's bottom edge.
     let remove = ui
-        .put(overlay_rect, egui::Button::new("×").small().frame(false))
+        .new_child(egui::UiBuilder::new().max_rect(overlay_rect).layout(
+            egui::Layout::centered_and_justified(egui::Direction::TopDown),
+        ))
+        .add(egui::Button::new("×").small().frame(false))
         .on_hover_text("Remove");
 
     if remove.clicked() {


### PR DESCRIPTION
Right-hand Results panel (View menu toggles it).

- Lists finished outputs of committed settings steps, newest first, up to 50; duplicate images merge.
- Entry: image (panel width, centered, at most 320 pt tall), one swatch row per palette, full settings on hover.
- Click applies the entry's settings as an undo step; the entry in use does not react.
- × overlay removes an entry.
- Generations during a drag are not recorded; the list clears when the input image changes.
- A result reaching the top animates: the slot opens, then the entry fades in.